### PR TITLE
feat: 프로젝트 단건 조회 API 구현

### DIFF
--- a/backend/src/main/java/moaon/backend/category/domain/Category.java
+++ b/backend/src/main/java/moaon/backend/category/domain/Category.java
@@ -24,4 +24,8 @@ public class Category {
 
     @Column(nullable = false, unique = true)
     private String name;
+
+    public Category(final String name) {
+        this.name = name;
+    }
 }

--- a/backend/src/main/java/moaon/backend/category/repository/CategoryRepository.java
+++ b/backend/src/main/java/moaon/backend/category/repository/CategoryRepository.java
@@ -1,0 +1,7 @@
+package moaon.backend.category.repository;
+
+import moaon.backend.category.domain.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/backend/src/main/java/moaon/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/moaon/backend/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package moaon.backend.global.exception;
+
+import moaon.backend.global.exception.custom.CustomException;
+import moaon.backend.global.exception.dto.ErrorResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        return ResponseEntity
+                .status(e.getStatus())
+                .body(ErrorResponse.from(e.getErrorCode()));
+    }
+}

--- a/backend/src/main/java/moaon/backend/global/exception/custom/CustomException.java
+++ b/backend/src/main/java/moaon/backend/global/exception/custom/CustomException.java
@@ -1,0 +1,19 @@
+package moaon.backend.global.exception.custom;
+
+import org.springframework.http.HttpStatus;
+
+public abstract class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+    public abstract HttpStatus getStatus();
+}

--- a/backend/src/main/java/moaon/backend/global/exception/custom/ErrorCode.java
+++ b/backend/src/main/java/moaon/backend/global/exception/custom/ErrorCode.java
@@ -1,0 +1,17 @@
+package moaon.backend.global.exception.custom;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+
+    PROJECT_NOT_FOUND("PROJECT-001", "프로젝트를 찾을 수 없습니다.");
+
+    private final String id;
+    private final String message;
+
+    ErrorCode(String id, String message) {
+        this.id = id;
+        this.message = message;
+    }
+}

--- a/backend/src/main/java/moaon/backend/global/exception/custom/NotFoundException.java
+++ b/backend/src/main/java/moaon/backend/global/exception/custom/NotFoundException.java
@@ -1,0 +1,15 @@
+package moaon.backend.global.exception.custom;
+
+import org.springframework.http.HttpStatus;
+
+public class NotFoundException extends CustomException {
+
+    public NotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.NOT_FOUND;
+    }
+}

--- a/backend/src/main/java/moaon/backend/global/exception/dto/ErrorResponse.java
+++ b/backend/src/main/java/moaon/backend/global/exception/dto/ErrorResponse.java
@@ -1,0 +1,19 @@
+package moaon.backend.global.exception.dto;
+
+import java.time.LocalDateTime;
+import moaon.backend.global.exception.custom.ErrorCode;
+
+public record ErrorResponse(
+        String errorId,
+        String message,
+        LocalDateTime timeStamp
+) {
+
+    public static ErrorResponse from(ErrorCode errorCode) {
+        return new ErrorResponse(
+                errorCode.getId(),
+                errorCode.getMessage(),
+                LocalDateTime.now()
+        );
+    }
+}

--- a/backend/src/main/java/moaon/backend/love/domain/Love.java
+++ b/backend/src/main/java/moaon/backend/love/domain/Love.java
@@ -10,8 +10,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import moaon.backend.member.domain.Member;
 import moaon.backend.project.domain.Project;
-import moaon.backend.user.domain.Member;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/backend/src/main/java/moaon/backend/love/domain/Love.java
+++ b/backend/src/main/java/moaon/backend/love/domain/Love.java
@@ -29,4 +29,9 @@ public class Love {
 
     @ManyToOne
     private Member member;
+
+    public Love(Project project, Member member) {
+        this.project = project;
+        this.member = member;
+    }
 }

--- a/backend/src/main/java/moaon/backend/love/repository/LoveRepository.java
+++ b/backend/src/main/java/moaon/backend/love/repository/LoveRepository.java
@@ -1,0 +1,9 @@
+package moaon.backend.love.repository;
+
+import moaon.backend.love.domain.Love;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LoveRepository extends JpaRepository<Love, Long> {
+
+    int countLoveByProjectId(Long projectId);
+}

--- a/backend/src/main/java/moaon/backend/member/domain/Member.java
+++ b/backend/src/main/java/moaon/backend/member/domain/Member.java
@@ -1,4 +1,4 @@
-package moaon.backend.user.domain;
+package moaon.backend.member.domain;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -20,4 +20,10 @@ public class Member {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    private String name;
+
+    public Member(String name) {
+        this.name = name;
+    }
 }

--- a/backend/src/main/java/moaon/backend/member/repository/MemberRepository.java
+++ b/backend/src/main/java/moaon/backend/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package moaon.backend.member.repository;
+
+import moaon.backend.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/backend/src/main/java/moaon/backend/organization/domain/Organization.java
+++ b/backend/src/main/java/moaon/backend/organization/domain/Organization.java
@@ -1,4 +1,4 @@
-package moaon.backend.group.domain;
+package moaon.backend.organization.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -25,4 +25,8 @@ public class Organization extends BaseTimeEntity {
 
     @Column(nullable = false, unique = true)
     private String name;
+
+    public Organization(String name) {
+        this.name = name;
+    }
 }

--- a/backend/src/main/java/moaon/backend/organization/repository/OrganizationRepository.java
+++ b/backend/src/main/java/moaon/backend/organization/repository/OrganizationRepository.java
@@ -1,0 +1,7 @@
+package moaon.backend.organization.repository;
+
+import moaon.backend.organization.domain.Organization;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrganizationRepository extends JpaRepository<Organization, Long> {
+}

--- a/backend/src/main/java/moaon/backend/platform/domain/Platform.java
+++ b/backend/src/main/java/moaon/backend/platform/domain/Platform.java
@@ -24,4 +24,8 @@ public class Platform {
 
     @Column(nullable = false, unique = true)
     private String name;
+
+    public Platform(final String name) {
+        this.name = name;
+    }
 }

--- a/backend/src/main/java/moaon/backend/platform/repository/PlatformRepository.java
+++ b/backend/src/main/java/moaon/backend/platform/repository/PlatformRepository.java
@@ -1,0 +1,7 @@
+package moaon.backend.platform.repository;
+
+import moaon.backend.platform.domain.Platform;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlatformRepository extends JpaRepository<Platform, Long> {
+}

--- a/backend/src/main/java/moaon/backend/project/controller/ProjectController.java
+++ b/backend/src/main/java/moaon/backend/project/controller/ProjectController.java
@@ -1,0 +1,23 @@
+package moaon.backend.project.controller;
+
+import lombok.RequiredArgsConstructor;
+import moaon.backend.project.dto.ProjectDetailResponse;
+import moaon.backend.project.service.ProjectService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/projects")
+@RequiredArgsConstructor
+public class ProjectController {
+
+    private final ProjectService projectService;
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ProjectDetailResponse> getProjectById(@PathVariable("id") long id) {
+        return ResponseEntity.ok(projectService.getById(id));
+    }
+}

--- a/backend/src/main/java/moaon/backend/project/domain/Images.java
+++ b/backend/src/main/java/moaon/backend/project/domain/Images.java
@@ -3,8 +3,15 @@ package moaon.backend.project.domain;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Embeddable;
 import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
 public class Images {
 
     @ElementCollection

--- a/backend/src/main/java/moaon/backend/project/domain/Project.java
+++ b/backend/src/main/java/moaon/backend/project/domain/Project.java
@@ -16,10 +16,10 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import moaon.backend.category.domain.Category;
 import moaon.backend.global.domain.BaseTimeEntity;
-import moaon.backend.group.domain.Organization;
+import moaon.backend.member.domain.Member;
+import moaon.backend.organization.domain.Organization;
 import moaon.backend.platform.domain.Platform;
 import moaon.backend.techStack.domain.TechStack;
-import moaon.backend.user.domain.Member;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -67,4 +67,25 @@ public class Project extends BaseTimeEntity {
 
     @ManyToMany
     private List<Platform> platforms;
+
+    public Project(
+            String title, String summary, String description,
+            String githubUrl, String productionUrl, Images imageUrls,
+            int views,
+            Organization organization, Member author,
+            List<TechStack> techStacks, List<Category> categories, List<Platform> platforms
+    ) {
+        this.title = title;
+        this.summary = summary;
+        this.description = description;
+        this.githubUrl = githubUrl;
+        this.productionUrl = productionUrl;
+        this.imageUrls = imageUrls;
+        this.views = views;
+        this.organization = organization;
+        this.author = author;
+        this.techStacks = techStacks;
+        this.categories = categories;
+        this.platforms = platforms;
+    }
 }

--- a/backend/src/main/java/moaon/backend/project/domain/Project.java
+++ b/backend/src/main/java/moaon/backend/project/domain/Project.java
@@ -88,4 +88,8 @@ public class Project extends BaseTimeEntity {
         this.categories = categories;
         this.platforms = platforms;
     }
+
+    public void addViewCount() {
+        views++;
+    }
 }

--- a/backend/src/main/java/moaon/backend/project/dto/ProjectDetailResponse.java
+++ b/backend/src/main/java/moaon/backend/project/dto/ProjectDetailResponse.java
@@ -26,7 +26,7 @@ public record ProjectDetailResponse(
         String productionUrl
 ) {
 
-    public static ProjectDetailResponse from(Project project) {
+    public static ProjectDetailResponse from(Project project, int loves) {
         return new ProjectDetailResponse(
                 project.getId(),
                 project.getAuthor().getId(),
@@ -45,7 +45,7 @@ public record ProjectDetailResponse(
                         .toList(),
                 project.getImageUrls().getUrls(),
                 false, // TODO 로그인 추가 시 수정
-                0, // TODO 조금 이따 수정
+                loves,
                 project.getViews(),
                 project.getCreatedAt(),
                 project.getGithubUrl(),

--- a/backend/src/main/java/moaon/backend/project/dto/ProjectDetailResponse.java
+++ b/backend/src/main/java/moaon/backend/project/dto/ProjectDetailResponse.java
@@ -2,6 +2,10 @@ package moaon.backend.project.dto;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import moaon.backend.category.domain.Category;
+import moaon.backend.platform.domain.Platform;
+import moaon.backend.project.domain.Project;
+import moaon.backend.techStack.domain.TechStack;
 
 public record ProjectDetailResponse(
         long id,
@@ -9,7 +13,7 @@ public record ProjectDetailResponse(
         String title,
         String summary,
         String description,
-        String group,
+        String organization,
         List<String> techStacks,
         List<String> platforms,
         List<String> categories,
@@ -21,4 +25,31 @@ public record ProjectDetailResponse(
         String githubUrl,
         String productionUrl
 ) {
+
+    public static ProjectDetailResponse from(Project project) {
+        return new ProjectDetailResponse(
+                project.getId(),
+                project.getAuthor().getId(),
+                project.getTitle(),
+                project.getSummary(),
+                project.getDescription(),
+                project.getOrganization().getName(),
+                project.getTechStacks().stream()
+                        .map(TechStack::getName)
+                        .toList(),
+                project.getPlatforms().stream()
+                        .map(Platform::getName)
+                        .toList(),
+                project.getCategories().stream()
+                        .map(Category::getName)
+                        .toList(),
+                project.getImageUrls().getUrls(),
+                false, // TODO 로그인 추가 시 수정
+                0, // TODO 조금 이따 수정
+                project.getViews(),
+                project.getCreatedAt(),
+                project.getGithubUrl(),
+                project.getProductionUrl()
+        );
+    }
 }

--- a/backend/src/main/java/moaon/backend/project/dto/ProjectDetailResponse.java
+++ b/backend/src/main/java/moaon/backend/project/dto/ProjectDetailResponse.java
@@ -1,0 +1,24 @@
+package moaon.backend.project.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ProjectDetailResponse(
+        long id,
+        long authorId,
+        String title,
+        String summary,
+        String description,
+        String group,
+        List<String> techStacks,
+        List<String> platforms,
+        List<String> categories,
+        List<String> imageUrls,
+        boolean isLoved,
+        int loves,
+        int views,
+        LocalDateTime createdAt,
+        String githubUrl,
+        String productionUrl
+) {
+}

--- a/backend/src/main/java/moaon/backend/project/repository/ProjectRepository.java
+++ b/backend/src/main/java/moaon/backend/project/repository/ProjectRepository.java
@@ -1,0 +1,7 @@
+package moaon.backend.project.repository;
+
+import moaon.backend.project.domain.Project;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+}

--- a/backend/src/main/java/moaon/backend/project/service/ProjectService.java
+++ b/backend/src/main/java/moaon/backend/project/service/ProjectService.java
@@ -1,6 +1,7 @@
 package moaon.backend.project.service;
 
 import lombok.RequiredArgsConstructor;
+import moaon.backend.love.repository.LoveRepository;
 import moaon.backend.project.domain.Project;
 import moaon.backend.project.dto.ProjectDetailResponse;
 import moaon.backend.project.repository.ProjectRepository;
@@ -13,10 +14,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProjectService {
 
     private final ProjectRepository projectRepository;
+    private final LoveRepository loveRepository;
 
     public ProjectDetailResponse getById(Long id) {
         Project project = projectRepository.findById(id)
                 .orElseThrow();
-        return ProjectDetailResponse.from(project);
+        int loves = loveRepository.countLoveByProjectId(id);
+        return ProjectDetailResponse.from(project, loves);
     }
 }

--- a/backend/src/main/java/moaon/backend/project/service/ProjectService.java
+++ b/backend/src/main/java/moaon/backend/project/service/ProjectService.java
@@ -1,6 +1,8 @@
 package moaon.backend.project.service;
 
 import lombok.RequiredArgsConstructor;
+import moaon.backend.global.exception.custom.ErrorCode;
+import moaon.backend.global.exception.custom.NotFoundException;
 import moaon.backend.love.repository.LoveRepository;
 import moaon.backend.project.domain.Project;
 import moaon.backend.project.dto.ProjectDetailResponse;
@@ -18,7 +20,7 @@ public class ProjectService {
 
     public ProjectDetailResponse getById(Long id) {
         Project project = projectRepository.findById(id)
-                .orElseThrow();
+                .orElseThrow(() -> new NotFoundException(ErrorCode.PROJECT_NOT_FOUND));
         int loves = loveRepository.countLoveByProjectId(id);
         return ProjectDetailResponse.from(project, loves);
     }

--- a/backend/src/main/java/moaon/backend/project/service/ProjectService.java
+++ b/backend/src/main/java/moaon/backend/project/service/ProjectService.java
@@ -1,0 +1,22 @@
+package moaon.backend.project.service;
+
+import lombok.RequiredArgsConstructor;
+import moaon.backend.project.domain.Project;
+import moaon.backend.project.dto.ProjectDetailResponse;
+import moaon.backend.project.repository.ProjectRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ProjectService {
+
+    private final ProjectRepository projectRepository;
+
+    public ProjectDetailResponse getById(Long id) {
+        Project project = projectRepository.findById(id)
+                .orElseThrow();
+        return ProjectDetailResponse.from(project);
+    }
+}

--- a/backend/src/main/java/moaon/backend/project/service/ProjectService.java
+++ b/backend/src/main/java/moaon/backend/project/service/ProjectService.java
@@ -18,9 +18,11 @@ public class ProjectService {
     private final ProjectRepository projectRepository;
     private final LoveRepository loveRepository;
 
+    @Transactional
     public ProjectDetailResponse getById(Long id) {
         Project project = projectRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.PROJECT_NOT_FOUND));
+        project.addViewCount();
         int loves = loveRepository.countLoveByProjectId(id);
         return ProjectDetailResponse.from(project, loves);
     }

--- a/backend/src/main/java/moaon/backend/techStack/domain/TechStack.java
+++ b/backend/src/main/java/moaon/backend/techStack/domain/TechStack.java
@@ -24,4 +24,8 @@ public class TechStack {
 
     @Column(nullable = false, unique = true)
     private String name;
+
+    public TechStack(String name) {
+        this.name = name;
+    }
 }

--- a/backend/src/main/java/moaon/backend/techStack/repository/TechStackRepository.java
+++ b/backend/src/main/java/moaon/backend/techStack/repository/TechStackRepository.java
@@ -1,0 +1,7 @@
+package moaon.backend.techStack.repository;
+
+import moaon.backend.techStack.domain.TechStack;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TechStackRepository extends JpaRepository<TechStack, Long> {
+}

--- a/backend/src/test/java/moaon/backend/api/project/ProjectApiTest.java
+++ b/backend/src/test/java/moaon/backend/api/project/ProjectApiTest.java
@@ -108,7 +108,8 @@ public class ProjectApiTest {
                 () -> assertThat(actualResponse.techStacks()).contains("java", "javaScript", "springBoot", "mysql"),
                 () -> assertThat(actualResponse.organization()).isEqualTo("그룹명"),
                 () -> assertThat(actualResponse.platforms()).contains("web"),
-                () -> assertThat(actualResponse.loves()).isEqualTo(1)
+                () -> assertThat(actualResponse.loves()).isEqualTo(1),
+                () -> assertThat(actualResponse.views()).isEqualTo(1)
         );
     }
 }

--- a/backend/src/test/java/moaon/backend/api/project/ProjectApiTest.java
+++ b/backend/src/test/java/moaon/backend/api/project/ProjectApiTest.java
@@ -7,6 +7,8 @@ import io.restassured.RestAssured;
 import java.util.List;
 import moaon.backend.category.domain.Category;
 import moaon.backend.category.repository.CategoryRepository;
+import moaon.backend.love.domain.Love;
+import moaon.backend.love.repository.LoveRepository;
 import moaon.backend.member.domain.Member;
 import moaon.backend.member.repository.MemberRepository;
 import moaon.backend.organization.domain.Organization;
@@ -54,6 +56,9 @@ public class ProjectApiTest {
     @Autowired
     PlatformRepository platformRepository;
 
+    @Autowired
+    LoveRepository loveRepository;
+
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
@@ -72,7 +77,7 @@ public class ProjectApiTest {
         Category category1 = categoryRepository.save(new Category("sports"));
         Category category2 = categoryRepository.save(new Category("book"));
         Platform platform = platformRepository.save(new Platform("web"));
-        projectRepository.save(new Project(
+        Project project = projectRepository.save(new Project(
                 "제목",
                 "한 줄 소개",
                 "상세 설명",
@@ -86,6 +91,7 @@ public class ProjectApiTest {
                 List.of(category1, category2),
                 List.of(platform)
         ));
+        loveRepository.save(new Love(project, member));
 
         // when
         ProjectDetailResponse actualResponse = RestAssured.given().log().all()
@@ -101,7 +107,8 @@ public class ProjectApiTest {
                 () -> assertThat(actualResponse.description()).isEqualTo("상세 설명"),
                 () -> assertThat(actualResponse.techStacks()).contains("java", "javaScript", "springBoot", "mysql"),
                 () -> assertThat(actualResponse.organization()).isEqualTo("그룹명"),
-                () -> assertThat(actualResponse.platforms()).contains("web")
+                () -> assertThat(actualResponse.platforms()).contains("web"),
+                () -> assertThat(actualResponse.loves()).isEqualTo(1)
         );
     }
 }

--- a/backend/src/test/java/moaon/backend/api/project/ProjectApiTest.java
+++ b/backend/src/test/java/moaon/backend/api/project/ProjectApiTest.java
@@ -1,0 +1,52 @@
+package moaon.backend.api.project;
+
+import io.restassured.RestAssured;
+import moaon.backend.project.dto.ProjectDetailResponse;
+import moaon.backend.project.repository.ProjectRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
+public class ProjectApiTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    ProjectRepository projectRepository;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @DisplayName("GET /projects/{id} : 프로젝트 단건 조회 API")
+    @Test
+    void findProject() {
+        // given
+//        Project project1 = projectRepository.save(new Project("제목", "썸네일", "설명"));
+//        Project project2 = projectRepository.save(new Project("제목", "썸네일", "설명"));
+
+        // when
+        ProjectDetailResponse actualResponse = RestAssured.given().log().all()
+                .when().get("/projects/1")
+                .then().log().all()
+                .statusCode(200)
+                .extract().as(ProjectDetailResponse.class);
+
+        // then
+//        assertAll(
+//                () -> assertThat(actualResponses).hasSize(2),
+//                () -> assertThat(actualResponses[0]).isEqualTo(ProjectSummaryResponse.from(project1)),
+//                () -> assertThat(actualResponses[1]).isEqualTo(ProjectSummaryResponse.from(project2))
+//        );
+    }
+}

--- a/backend/src/test/java/moaon/backend/api/project/ProjectApiTest.java
+++ b/backend/src/test/java/moaon/backend/api/project/ProjectApiTest.java
@@ -1,8 +1,24 @@
 package moaon.backend.api.project;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import io.restassured.RestAssured;
+import java.util.List;
+import moaon.backend.category.domain.Category;
+import moaon.backend.category.repository.CategoryRepository;
+import moaon.backend.member.domain.Member;
+import moaon.backend.member.repository.MemberRepository;
+import moaon.backend.organization.domain.Organization;
+import moaon.backend.organization.repository.OrganizationRepository;
+import moaon.backend.platform.domain.Platform;
+import moaon.backend.platform.repository.PlatformRepository;
+import moaon.backend.project.domain.Images;
+import moaon.backend.project.domain.Project;
 import moaon.backend.project.dto.ProjectDetailResponse;
 import moaon.backend.project.repository.ProjectRepository;
+import moaon.backend.techStack.domain.TechStack;
+import moaon.backend.techStack.repository.TechStackRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,6 +39,21 @@ public class ProjectApiTest {
     @Autowired
     ProjectRepository projectRepository;
 
+    @Autowired
+    OrganizationRepository organizationRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    TechStackRepository techStackRepository;
+
+    @Autowired
+    CategoryRepository categoryRepository;
+
+    @Autowired
+    PlatformRepository platformRepository;
+
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
@@ -32,8 +63,29 @@ public class ProjectApiTest {
     @Test
     void findProject() {
         // given
-//        Project project1 = projectRepository.save(new Project("제목", "썸네일", "설명"));
-//        Project project2 = projectRepository.save(new Project("제목", "썸네일", "설명"));
+        Organization organization = organizationRepository.save(new Organization("그룹명"));
+        Member member = memberRepository.save(new Member("글쓴이"));
+        TechStack techStack1 = techStackRepository.save(new TechStack("java"));
+        TechStack techStack2 = techStackRepository.save(new TechStack("javaScript"));
+        TechStack techStack3 = techStackRepository.save(new TechStack("springBoot"));
+        TechStack techStack4 = techStackRepository.save(new TechStack("mysql"));
+        Category category1 = categoryRepository.save(new Category("sports"));
+        Category category2 = categoryRepository.save(new Category("book"));
+        Platform platform = platformRepository.save(new Platform("web"));
+        projectRepository.save(new Project(
+                "제목",
+                "한 줄 소개",
+                "상세 설명",
+                "깃허브 URL",
+                "프로덕션 URL",
+                new Images(List.of("이미지 URL1", "이미지 URL2")),
+                0,
+                organization,
+                member,
+                List.of(techStack1, techStack2, techStack3, techStack4),
+                List.of(category1, category2),
+                List.of(platform)
+        ));
 
         // when
         ProjectDetailResponse actualResponse = RestAssured.given().log().all()
@@ -43,10 +95,13 @@ public class ProjectApiTest {
                 .extract().as(ProjectDetailResponse.class);
 
         // then
-//        assertAll(
-//                () -> assertThat(actualResponses).hasSize(2),
-//                () -> assertThat(actualResponses[0]).isEqualTo(ProjectSummaryResponse.from(project1)),
-//                () -> assertThat(actualResponses[1]).isEqualTo(ProjectSummaryResponse.from(project2))
-//        );
+        assertAll(
+                () -> assertThat(actualResponse.title()).isEqualTo("제목"),
+                () -> assertThat(actualResponse.summary()).isEqualTo("한 줄 소개"),
+                () -> assertThat(actualResponse.description()).isEqualTo("상세 설명"),
+                () -> assertThat(actualResponse.techStacks()).contains("java", "javaScript", "springBoot", "mysql"),
+                () -> assertThat(actualResponse.organization()).isEqualTo("그룹명"),
+                () -> assertThat(actualResponse.platforms()).contains("web")
+        );
     }
 }

--- a/backend/src/test/java/moaon/backend/project/service/ProjectServiceTest.java
+++ b/backend/src/test/java/moaon/backend/project/service/ProjectServiceTest.java
@@ -1,0 +1,32 @@
+package moaon.backend.project.service;
+
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import moaon.backend.global.exception.custom.ErrorCode;
+import moaon.backend.global.exception.custom.NotFoundException;
+import moaon.backend.project.repository.ProjectRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectServiceTest {
+
+    @Mock
+    private ProjectRepository projectRepository;
+
+    @InjectMocks
+    private ProjectService projectService;
+
+    @DisplayName("ID에 해당하는 프로젝트가 존재하지 않는다면 예외가 발생한다.")
+    @Test
+    void getProjectById() {
+        assertThatThrownBy(() -> projectService.getById(1L))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ErrorCode.PROJECT_NOT_FOUND.getMessage());
+    }
+}


### PR DESCRIPTION
# 🎯 이슈 번호

- close #24 

## ✅ 체크 리스트

- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 🏁 작업 내용

- `GET /projects/{id}` API 구현
- 테스트: 통합 테스트, 서비스 단위 테스트
- CustomException 관련 설정들 추가
- API Not Found 예외 처리
- API 호출시 조회수 증가 로직 구현

## 🎸 기타

- 메서드명 괜찮은지 확인해주세요
- CustomException을 활용한 방식이 괜찮은지 의견 주세요(예외 계층,`ErrorCode` ENUM의 id 활용)
- `ProjectService`에서 `orElseThrow()` 하는 로직을 레포지터리 계층에 넣을까 고민하다가 해당 로직은 비즈니스 로직에 가깝다고 판단하여 서비스 계층에 두었습니다.
