### PR TITLE
fix: styled 문법 포맷 안되는 문제 해결

### DIFF
--- a/frontend/.vscode/extensions.json
+++ b/frontend/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["biomejs.biome"]
+  "recommendations": ["biomejs.biome", "esbenp.prettier-vscode"]
 }

--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -1,8 +1,17 @@
 {
   "editor.defaultFormatter": "biomejs.biome",
+  "files.associations": {
+    "*.styled.ts": "javascriptreact" // 해당 파일을 jsx 방식으로 인식
+  },
+  "[javascriptreact]": {
+    // jsx 방식은 prettier로 포맷팅
+    // jsx 파일은 존재하지 않음, styled 포맷 목적
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
     "source.fixAll": "always",
     "source.organizeImports.biome": "explicit"
-  }
+  },
+  "externalFormatters.languages": {}
 }


### PR DESCRIPTION
# 🎯 이슈 번호

close #32 

## ✅ 체크 리스트

- [X] Target Branch를 올바르게 설정했나요?
- [X] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 🏁 작업 내용

**VS Code 포맷팅 설정 개선**
- `*.styled.ts` 파일들만 Prettier로 포맷팅하도록 VS Code 설정 변경
- 나머지 파일들(`.ts`, `.tsx`)은 Biome 포맷팅 유지하여 속도와 일관성 확보
- `files.associations`를 통한 커스텀 언어 모드 매핑 적용

- [관련 내용 문서화](https://www.notion.so/Biome-styled-2374b52230648015afdceea22cfafbe3?source=copy_link)

## 🎸 기타

**기술적 배경 및 설계 결정사항**
- 문제: Biome의 CSS-in-JS 템플릿 리터럴 포맷팅 제한으로 `@emotion/styled` 코드가 정리되지 않는 이슈
- 해결 방향: 각 도구의 강점을 활용한 하이브리드 접근 방식 채택
- 의존성 최소화: `Prettier`를 패키지 의존성으로 추가하지 않고 VS Code 확장 프로그램만 활용

**팀 협업 고려사항**
- `.vscode/extensions.json`에 필수 확장 프로그램(`biomejs.biome`, `esbenp.prettier-vscode`) 추천 설정 추가
- 새로운 팀원 온보딩 시 자동으로 필요한 도구 설치 안내
- 설정 변경 시 즉시 적용되므로 별도 빌드 도구 재시작 불필요

**코드 구성 및 유지보수성**

- 파일 확장자 기반 명확한 역할 분리: `.styled.ts`는 스타일 전용, 나머지는 로직 전용
- 향후 Biome의 CSS-in-JS 지원이 개선되면 설정 롤백 가능한 구조 유지
- 프로덕션 빌드에는 영향 없는 개발 환경 전용 설정

