### PR TITLE
feat(BE): 아티클 무한스크롤 및 정렬 기능 구현

### DIFF
--- a/backend/src/main/java/moaon/backend/article/controller/ArticleController.java
+++ b/backend/src/main/java/moaon/backend/article/controller/ArticleController.java
@@ -1,0 +1,41 @@
+package moaon.backend.article.controller;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import moaon.backend.article.dto.ArticleQueryCondition;
+import moaon.backend.article.dto.ArticleResponse;
+import moaon.backend.article.service.ArticleService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/articles")
+@RequiredArgsConstructor
+public class ArticleController {
+
+    private final ArticleService articleService;
+
+    @GetMapping
+    public ResponseEntity<ArticleResponse> getPagedArticles(
+            @RequestParam(value = "sort", required = false) String sortType,
+            @RequestParam(value = "techStacks", required = false) List<String> techStacks,
+            @RequestParam(value = "category", required = false) String category,
+            @RequestParam(value = "search", required = false) String search,
+            @RequestParam(value = "limit") int limit,
+            @RequestParam(value = "cursor") String cursor
+    ) {
+        ArticleQueryCondition queryCondition = ArticleQueryCondition.from(
+                search,
+                category,
+                techStacks,
+                sortType,
+                limit,
+                cursor
+        );
+
+        return ResponseEntity.ok(articleService.getPagedArticles(queryCondition));
+    }
+}

--- a/backend/src/main/java/moaon/backend/article/domain/Article.java
+++ b/backend/src/main/java/moaon/backend/article/domain/Article.java
@@ -74,7 +74,6 @@ public class Article extends BaseTimeEntity {
             String summary,
             String content,
             String articleUrl,
-            int clicks,
             LocalDateTime createdAt,
             Project project,
             ArticleCategory category,
@@ -84,7 +83,7 @@ public class Article extends BaseTimeEntity {
         this.summary = summary;
         this.content = content;
         this.articleUrl = articleUrl;
-        this.clicks = clicks;
+        this.clicks = 0;
         this.createdAt = createdAt;
         this.project = project;
         this.category = category;

--- a/backend/src/main/java/moaon/backend/article/domain/Article.java
+++ b/backend/src/main/java/moaon/backend/article/domain/Article.java
@@ -6,11 +6,16 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,6 +29,13 @@ import moaon.backend.techStack.domain.TechStack;
 @Getter
 @EqualsAndHashCode(of = "id", callSuper = false)
 @ToString
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Table(indexes = {
+        @Index(name = "idx_article_created_at_id", columnList = "createdAt DESC, id DESC"),
+        @Index(name = "idx_article_clicks_id", columnList = "clicks DESC, id DESC")
+})
+
 public class Article extends BaseTimeEntity {
 
     @Id
@@ -55,5 +67,31 @@ public class Article extends BaseTimeEntity {
     private ArticleCategory category;
 
     @ManyToMany
-    private List<TechStack> techStacks; // TODO 방어적 복사 getter
+    private List<TechStack> techStacks;
+
+    public Article(
+            String title,
+            String summary,
+            String content,
+            String articleUrl,
+            int clicks,
+            LocalDateTime createdAt,
+            Project project,
+            ArticleCategory category,
+            List<TechStack> techStacks
+    ) {
+        this.title = title;
+        this.summary = summary;
+        this.content = content;
+        this.articleUrl = articleUrl;
+        this.clicks = clicks;
+        this.createdAt = createdAt;
+        this.project = project;
+        this.category = category;
+        this.techStacks = new ArrayList<>(techStacks);
+    }
+
+    public List<TechStack> getTechStacks() {
+        return List.copyOf(techStacks);
+    }
 }

--- a/backend/src/main/java/moaon/backend/article/domain/ArticleCategory.java
+++ b/backend/src/main/java/moaon/backend/article/domain/ArticleCategory.java
@@ -24,4 +24,8 @@ public class ArticleCategory {
 
     @Column(nullable = false, unique = true)
     private String name;
+
+    public ArticleCategory(String name) {
+        this.name = name;
+    }
 }

--- a/backend/src/main/java/moaon/backend/article/domain/ArticleSortBy.java
+++ b/backend/src/main/java/moaon/backend/article/domain/ArticleSortBy.java
@@ -1,0 +1,20 @@
+package moaon.backend.article.domain;
+
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum ArticleSortBy {
+
+    CREATED_AT("createdAt"),
+    CLICKS("clicks");
+
+    private final String sortType;
+
+    public static ArticleSortBy from(String sortType) {
+        return Arrays.stream(ArticleSortBy.values())
+                .filter(articleSortBy -> articleSortBy.sortType.equals(sortType))
+                .findAny()
+                .orElse(CREATED_AT);
+    }
+}

--- a/backend/src/main/java/moaon/backend/article/dto/ArticleContent.java
+++ b/backend/src/main/java/moaon/backend/article/dto/ArticleContent.java
@@ -5,7 +5,7 @@ import java.util.List;
 import moaon.backend.article.domain.Article;
 import moaon.backend.techStack.domain.TechStack;
 
-public record Content(
+public record ArticleContent(
         Long id,
         Long projectId,
         int clicks,
@@ -17,8 +17,8 @@ public record Content(
         LocalDateTime createdAt
 ) {
 
-    public static Content from(Article article) {
-        return new Content(
+    public static ArticleContent from(Article article) {
+        return new ArticleContent(
                 article.getId(),
                 article.getProject().getId(),
                 article.getClicks(),
@@ -33,9 +33,9 @@ public record Content(
         );
     }
 
-    public static List<Content> from(List<Article> articles) {
+    public static List<ArticleContent> from(List<Article> articles) {
         return articles.stream()
-                .map(Content::from)
+                .map(ArticleContent::from)
                 .toList();
     }
 }

--- a/backend/src/main/java/moaon/backend/article/dto/ArticleQueryCondition.java
+++ b/backend/src/main/java/moaon/backend/article/dto/ArticleQueryCondition.java
@@ -1,0 +1,33 @@
+package moaon.backend.article.dto;
+
+import java.util.List;
+import moaon.backend.article.domain.ArticleSortBy;
+
+public record ArticleQueryCondition(
+        String search,
+        String categoryName,
+        List<String> techStackNames,
+        ArticleSortBy sortBy,
+        int limit,
+        Cursor<?> cursor
+) {
+
+    public static ArticleQueryCondition from(
+            String search,
+            String categoryName,
+            List<String> techStackNames,
+            String sortType,
+            int limit,
+            String cursor
+    ) {
+        ArticleSortBy sortBy = ArticleSortBy.from(sortType);
+        return new ArticleQueryCondition(
+                search,
+                categoryName,
+                techStackNames,
+                sortBy,
+                limit,
+                CursorParser.toCursor(cursor, sortBy)
+        );
+    }
+}

--- a/backend/src/main/java/moaon/backend/article/dto/ArticleResponse.java
+++ b/backend/src/main/java/moaon/backend/article/dto/ArticleResponse.java
@@ -1,0 +1,26 @@
+package moaon.backend.article.dto;
+
+import java.util.List;
+import moaon.backend.article.domain.Article;
+
+public record ArticleResponse(
+        List<Content> contents,
+        int totalCount,
+        boolean hasNext,
+        String nextCursor
+) {
+
+    public static ArticleResponse from(
+            List<Article> articles,
+            Long totalCount,
+            boolean hasNext,
+            String nextCursor
+    ) {
+        return new ArticleResponse(
+                Content.from(articles),
+                totalCount.intValue(),
+                hasNext,
+                nextCursor
+        );
+    }
+}

--- a/backend/src/main/java/moaon/backend/article/dto/ArticleResponse.java
+++ b/backend/src/main/java/moaon/backend/article/dto/ArticleResponse.java
@@ -4,7 +4,7 @@ import java.util.List;
 import moaon.backend.article.domain.Article;
 
 public record ArticleResponse(
-        List<Content> contents,
+        List<ArticleContent> articleContents,
         int totalCount,
         boolean hasNext,
         String nextCursor
@@ -17,7 +17,7 @@ public record ArticleResponse(
             String nextCursor
     ) {
         return new ArticleResponse(
-                Content.from(articles),
+                ArticleContent.from(articles),
                 totalCount.intValue(),
                 hasNext,
                 nextCursor

--- a/backend/src/main/java/moaon/backend/article/dto/ClickCursor.java
+++ b/backend/src/main/java/moaon/backend/article/dto/ClickCursor.java
@@ -1,5 +1,8 @@
 package moaon.backend.article.dto;
 
+import static moaon.backend.article.domain.QArticle.article;
+
+import com.querydsl.core.BooleanBuilder;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -21,5 +24,12 @@ public class ClickCursor implements Cursor<Integer> {
     @Override
     public String getNextCursor() {
         return clicks + "_" + id;
+    }
+
+    @Override
+    public void applyCursor(ArticleQueryCondition queryCondition, BooleanBuilder whereBuilder) {
+        whereBuilder.and(article.clicks.lt(getSortValue())
+                .or(article.clicks.eq(getSortValue())
+                        .and(article.id.lt(getLastId()))));
     }
 }

--- a/backend/src/main/java/moaon/backend/article/dto/ClickCursor.java
+++ b/backend/src/main/java/moaon/backend/article/dto/ClickCursor.java
@@ -1,0 +1,25 @@
+package moaon.backend.article.dto;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ClickCursor implements Cursor<Integer> {
+
+    private final int clicks;
+    private final Long id;
+
+    @Override
+    public Integer getSortValue() {
+        return clicks;
+    }
+
+    @Override
+    public Long getLastId() {
+        return id;
+    }
+
+    @Override
+    public String getNextCursor() {
+        return clicks + "_" + id;
+    }
+}

--- a/backend/src/main/java/moaon/backend/article/dto/Content.java
+++ b/backend/src/main/java/moaon/backend/article/dto/Content.java
@@ -1,0 +1,41 @@
+package moaon.backend.article.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import moaon.backend.article.domain.Article;
+import moaon.backend.techStack.domain.TechStack;
+
+public record Content(
+        Long id,
+        Long projectId,
+        int clicks,
+        String title,
+        String summary,
+        List<String> techStacks,
+        String url,
+        String category,
+        LocalDateTime createdAt
+) {
+
+    public static Content from(Article article) {
+        return new Content(
+                article.getId(),
+                article.getProject().getId(),
+                article.getClicks(),
+                article.getTitle(),
+                article.getSummary(),
+                article.getTechStacks().stream()
+                        .map(TechStack::getName)
+                        .toList(),
+                article.getArticleUrl(),
+                article.getCategory().getName(),
+                article.getCreatedAt()
+        );
+    }
+
+    public static List<Content> from(List<Article> articles) {
+        return articles.stream()
+                .map(Content::from)
+                .toList();
+    }
+}

--- a/backend/src/main/java/moaon/backend/article/dto/CreatedAtCursor.java
+++ b/backend/src/main/java/moaon/backend/article/dto/CreatedAtCursor.java
@@ -27,7 +27,7 @@ public class CreatedAtCursor implements Cursor<LocalDateTime> {
 
     @Override
     public String getNextCursor() {
-        return createdAt.format(FORMATTER) + "_" + id.toString();
+        return createdAt.format(FORMATTER) + "_" + id;
     }
 
     @Override

--- a/backend/src/main/java/moaon/backend/article/dto/CreatedAtCursor.java
+++ b/backend/src/main/java/moaon/backend/article/dto/CreatedAtCursor.java
@@ -1,5 +1,8 @@
 package moaon.backend.article.dto;
 
+import static moaon.backend.article.domain.QArticle.article;
+
+import com.querydsl.core.BooleanBuilder;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
@@ -25,5 +28,12 @@ public class CreatedAtCursor implements Cursor<LocalDateTime> {
     @Override
     public String getNextCursor() {
         return createdAt.format(FORMATTER) + "_" + id.toString();
+    }
+
+    @Override
+    public void applyCursor(ArticleQueryCondition queryCondition, BooleanBuilder whereBuilder) {
+        whereBuilder.and(article.createdAt.lt(getSortValue())
+                .or(article.createdAt.eq(getSortValue())
+                        .and(article.id.lt(getLastId()))));
     }
 }

--- a/backend/src/main/java/moaon/backend/article/dto/CreatedAtCursor.java
+++ b/backend/src/main/java/moaon/backend/article/dto/CreatedAtCursor.java
@@ -1,0 +1,29 @@
+package moaon.backend.article.dto;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CreatedAtCursor implements Cursor<LocalDateTime> {
+
+    private final LocalDateTime createdAt;
+    private final Long id;
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+    @Override
+    public LocalDateTime getSortValue() {
+        return createdAt;
+    }
+
+    @Override
+    public Long getLastId() {
+        return id;
+    }
+
+    @Override
+    public String getNextCursor() {
+        return createdAt.format(FORMATTER) + "_" + id.toString();
+    }
+}

--- a/backend/src/main/java/moaon/backend/article/dto/Cursor.java
+++ b/backend/src/main/java/moaon/backend/article/dto/Cursor.java
@@ -1,5 +1,7 @@
 package moaon.backend.article.dto;
 
+import com.querydsl.core.BooleanBuilder;
+
 public interface Cursor<T extends Comparable<? super T>> {
 
     T getSortValue();
@@ -7,4 +9,9 @@ public interface Cursor<T extends Comparable<? super T>> {
     Long getLastId();
 
     String getNextCursor();
+
+    void applyCursor(
+            ArticleQueryCondition queryCondition,
+            BooleanBuilder whereBuilder
+    );
 }

--- a/backend/src/main/java/moaon/backend/article/dto/Cursor.java
+++ b/backend/src/main/java/moaon/backend/article/dto/Cursor.java
@@ -1,0 +1,10 @@
+package moaon.backend.article.dto;
+
+public interface Cursor<T extends Comparable<? super T>> {
+
+    T getSortValue();
+
+    Long getLastId();
+
+    String getNextCursor();
+}

--- a/backend/src/main/java/moaon/backend/article/dto/CursorParser.java
+++ b/backend/src/main/java/moaon/backend/article/dto/CursorParser.java
@@ -7,22 +7,18 @@ import moaon.backend.article.domain.ArticleSortBy;
 public class CursorParser {
 
     public static Cursor<?> toCursor(String cursor, ArticleSortBy articleSortBy) {
-        if (articleSortBy == ArticleSortBy.CREATED_AT) {
-            String[] valueAndId = cursor.split("_");
+        String[] valueAndId = cursor.split("_");
 
-            String value = valueAndId[0];
-            String id = valueAndId[1];
+        String value = valueAndId[0];
+        String id = valueAndId[1];
+
+        if (articleSortBy == ArticleSortBy.CREATED_AT) {
 
             LocalDateTime lastCreatedAt = LocalDateTime.parse(value);
             Long lastId = Long.parseLong(id);
 
             return new CreatedAtCursor(lastCreatedAt, lastId);
         }
-
-        String[] valueAndId = cursor.split("_");
-
-        String value = valueAndId[0];
-        String id = valueAndId[1];
 
         int clicks = Integer.parseInt(value);
         Long lastId = Long.parseLong(id);

--- a/backend/src/main/java/moaon/backend/article/dto/CursorParser.java
+++ b/backend/src/main/java/moaon/backend/article/dto/CursorParser.java
@@ -1,0 +1,40 @@
+package moaon.backend.article.dto;
+
+import java.time.LocalDateTime;
+import moaon.backend.article.domain.Article;
+import moaon.backend.article.domain.ArticleSortBy;
+
+public class CursorParser {
+
+    public static Cursor<?> toCursor(String cursor, ArticleSortBy articleSortBy) {
+        if (articleSortBy == ArticleSortBy.CREATED_AT) {
+            String[] valueAndId = cursor.split("_");
+
+            String value = valueAndId[0];
+            String id = valueAndId[1];
+
+            LocalDateTime lastCreatedAt = LocalDateTime.parse(value);
+            Long lastId = Long.parseLong(id);
+
+            return new CreatedAtCursor(lastCreatedAt, lastId);
+        }
+
+        String[] valueAndId = cursor.split("_");
+
+        String value = valueAndId[0];
+        String id = valueAndId[1];
+
+        int clicks = Integer.parseInt(value);
+        Long lastId = Long.parseLong(id);
+
+        return new ClickCursor(clicks, lastId);
+    }
+
+    public static Cursor<?> toCursor(Article article, ArticleSortBy articleSortBy) {
+        if (articleSortBy == ArticleSortBy.CREATED_AT) {
+            return new CreatedAtCursor(article.getCreatedAt(), article.getId());
+        }
+
+        return new ClickCursor(article.getClicks(), article.getId());
+    }
+}

--- a/backend/src/main/java/moaon/backend/article/repository/ArticleCategoryRepository.java
+++ b/backend/src/main/java/moaon/backend/article/repository/ArticleCategoryRepository.java
@@ -1,0 +1,7 @@
+package moaon.backend.article.repository;
+
+import moaon.backend.article.domain.ArticleCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleCategoryRepository extends JpaRepository<ArticleCategory, Long> {
+}

--- a/backend/src/main/java/moaon/backend/article/repository/ArticleRepository.java
+++ b/backend/src/main/java/moaon/backend/article/repository/ArticleRepository.java
@@ -1,0 +1,7 @@
+package moaon.backend.article.repository;
+
+import moaon.backend.article.domain.Article;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleRepository extends JpaRepository<Article, Long>, CustomizedArticleRepository {
+}

--- a/backend/src/main/java/moaon/backend/article/repository/CustomizedArticleRepository.java
+++ b/backend/src/main/java/moaon/backend/article/repository/CustomizedArticleRepository.java
@@ -1,0 +1,10 @@
+package moaon.backend.article.repository;
+
+import java.util.List;
+import moaon.backend.article.domain.Article;
+import moaon.backend.article.dto.ArticleQueryCondition;
+
+public interface CustomizedArticleRepository {
+
+    List<Article> findWithSearchConditions(ArticleQueryCondition queryCondition);
+}

--- a/backend/src/main/java/moaon/backend/article/repository/CustomizedArticleRepositoryImpl.java
+++ b/backend/src/main/java/moaon/backend/article/repository/CustomizedArticleRepositoryImpl.java
@@ -40,7 +40,7 @@ public class CustomizedArticleRepositoryImpl implements CustomizedArticleReposit
         BooleanBuilder havingBuilder = new BooleanBuilder();
 
         if (categoryName != null && !categoryName.isEmpty()) {
-            whereBuilder.and(article.category.name.in(categoryName));
+            whereBuilder.and(article.category.name.eq(categoryName));
         }
 
         if (techStackNames != null && !techStackNames.isEmpty()) {

--- a/backend/src/main/java/moaon/backend/article/repository/CustomizedArticleRepositoryImpl.java
+++ b/backend/src/main/java/moaon/backend/article/repository/CustomizedArticleRepositoryImpl.java
@@ -1,0 +1,85 @@
+package moaon.backend.article.repository;
+
+import static moaon.backend.article.domain.QArticle.article;
+import static moaon.backend.article.domain.QArticleCategory.articleCategory;
+import static moaon.backend.techStack.domain.QTechStack.techStack;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import moaon.backend.article.domain.Article;
+import moaon.backend.article.domain.ArticleSortBy;
+import moaon.backend.article.dto.ArticleQueryCondition;
+import moaon.backend.article.dto.Cursor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomizedArticleRepositoryImpl implements CustomizedArticleRepository {
+
+    public static final int FETCH_EXTRA_FOR_HAS_NEXT = 1;
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<Article> findWithSearchConditions(ArticleQueryCondition queryCondition) {
+        String categoryName = queryCondition.categoryName();
+        List<String> techStackNames = queryCondition.techStackNames();
+        Cursor<?> cursor = queryCondition.cursor();
+
+        JPAQuery<Article> query = jpaQueryFactory.selectFrom(article)
+                .distinct()
+                .leftJoin(article.category, articleCategory)
+                .leftJoin(article.techStacks, techStack);
+
+        BooleanBuilder whereBuilder = new BooleanBuilder();
+        BooleanBuilder havingBuilder = new BooleanBuilder();
+
+        if (categoryName != null && !categoryName.isEmpty()) {
+            whereBuilder.and(article.category.name.in(categoryName));
+        }
+
+        if (techStackNames != null && !techStackNames.isEmpty()) {
+            whereBuilder.and(techStack.name.in(techStackNames));
+            havingBuilder.and(techStack.name.countDistinct().eq((long) techStackNames.size()));
+        }
+
+        if (queryCondition.sortBy() == ArticleSortBy.CLICKS) {
+            whereBuilder.and(article.clicks.lt((Integer) cursor.getSortValue())
+                    .or(article.clicks.eq((Integer) cursor.getSortValue())
+                            .and(article.id.lt(cursor.getLastId()))));
+        }
+
+        if (queryCondition.sortBy() == ArticleSortBy.CREATED_AT) {
+            whereBuilder.and(article.createdAt.lt((LocalDateTime) cursor.getSortValue())
+                    .or(article.createdAt.eq((LocalDateTime) cursor.getSortValue())
+                            .and(article.id.lt(cursor.getLastId()))));
+        }
+
+        if (whereBuilder.hasValue()) {
+            query.where(whereBuilder);
+        }
+
+        if (havingBuilder.hasValue()) {
+            query.having(havingBuilder);
+        }
+
+        query.groupBy(article.id)
+                .orderBy(toOrderBy(queryCondition.sortBy()))
+                .limit(queryCondition.limit() + FETCH_EXTRA_FOR_HAS_NEXT);
+
+        return query.fetch();
+    }
+
+    private OrderSpecifier<?>[] toOrderBy(ArticleSortBy sortBy) {
+        if (sortBy == ArticleSortBy.CLICKS) {
+            return new OrderSpecifier<?>[]{article.clicks.desc(), article.id.desc()};
+        }
+
+        return new OrderSpecifier<?>[]{article.createdAt.desc(), article.id.desc()};
+    }
+}

--- a/backend/src/main/java/moaon/backend/article/service/ArticleService.java
+++ b/backend/src/main/java/moaon/backend/article/service/ArticleService.java
@@ -1,0 +1,40 @@
+package moaon.backend.article.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import moaon.backend.article.domain.Article;
+import moaon.backend.article.dto.ArticleQueryCondition;
+import moaon.backend.article.dto.ArticleResponse;
+import moaon.backend.article.dto.Cursor;
+import moaon.backend.article.dto.CursorParser;
+import moaon.backend.article.repository.ArticleRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ArticleService {
+
+    private final ArticleRepository articleRepository;
+
+    public ArticleResponse getPagedArticles(ArticleQueryCondition queryCondition) {
+        List<Article> articles = articleRepository.findWithSearchConditions(queryCondition);
+        long totalCount = articleRepository.count();
+
+        if (articles.size() > queryCondition.limit()) {
+            List<Article> articlesToReturn = articles.subList(0, queryCondition.limit());
+            Article lastArticle = articles.getLast();
+
+            Cursor<?> cursor = CursorParser.toCursor(lastArticle, queryCondition.sortBy());
+
+            return ArticleResponse.from(
+                    articlesToReturn,
+                    totalCount,
+                    true,
+                    cursor.getNextCursor());
+        }
+
+        return ArticleResponse.from(articles, totalCount, false, "");
+    }
+}

--- a/backend/src/main/java/moaon/backend/article/service/ArticleService.java
+++ b/backend/src/main/java/moaon/backend/article/service/ArticleService.java
@@ -35,6 +35,6 @@ public class ArticleService {
                     cursor.getNextCursor());
         }
 
-        return ArticleResponse.from(articles, totalCount, false, "");
+        return ArticleResponse.from(articles, totalCount, false, null);
     }
 }

--- a/backend/src/test/java/moaon/backend/api/project/ArticleApiTest.java
+++ b/backend/src/test/java/moaon/backend/api/project/ArticleApiTest.java
@@ -143,12 +143,12 @@ public class ArticleApiTest {
 
         // then
         assertAll(
-                () -> assertThat(actualResponse.contents()).hasSize(3),
-                () -> assertThat(actualResponse.contents().getFirst().id()).isEqualTo(
+                () -> assertThat(actualResponse.articleContents()).hasSize(3),
+                () -> assertThat(actualResponse.articleContents().getFirst().id()).isEqualTo(
                         articleClickRankFirst.getId()),
-                () -> assertThat(actualResponse.contents().get(1).id()).isEqualTo(
+                () -> assertThat(actualResponse.articleContents().get(1).id()).isEqualTo(
                         articleClickRankSecond.getId()),
-                () -> assertThat(actualResponse.contents().get(2).id()).isEqualTo(
+                () -> assertThat(actualResponse.articleContents().get(2).id()).isEqualTo(
                         articleRankThirdHasBiggerId.getId())
         );
     }

--- a/backend/src/test/java/moaon/backend/api/project/ArticleApiTest.java
+++ b/backend/src/test/java/moaon/backend/api/project/ArticleApiTest.java
@@ -1,0 +1,155 @@
+package moaon.backend.api.project;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import io.restassured.RestAssured;
+import java.util.List;
+import moaon.backend.article.domain.Article;
+import moaon.backend.article.domain.ArticleCategory;
+import moaon.backend.article.dto.ArticleResponse;
+import moaon.backend.fixture.ArticleFixtureBuilder;
+import moaon.backend.fixture.Fixture;
+import moaon.backend.fixture.ProjectFixtureBuilder;
+import moaon.backend.fixture.RepositoryHelper;
+import moaon.backend.global.config.QueryDslConfig;
+import moaon.backend.project.domain.Project;
+import moaon.backend.techStack.domain.TechStack;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
+@Import({RepositoryHelper.class, QueryDslConfig.class})
+public class ArticleApiTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private RepositoryHelper repositoryHelper;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @DisplayName("GET /articles : 페이징 방식의 프로젝트 조회 API")
+    @Test
+    void getPagedArticles() {
+        // given
+        ArticleCategory filteredArticleCategory = Fixture.anyArticleCategory();
+        ArticleCategory unfilteredArticleCategory = Fixture.anyArticleCategory();
+
+        TechStack filteredTechStack = Fixture.anyTechStack();
+        TechStack unfilteredTechStack = Fixture.anyTechStack();
+
+        Project project = repositoryHelper.save(
+                new ProjectFixtureBuilder()
+                        .build()
+        );
+
+        repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .category(filteredArticleCategory)
+                        .techStacks(List.of(unfilteredTechStack))
+                        .project(project)
+                        .clicks(4)
+                        .build()
+        );
+
+        repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .category(unfilteredArticleCategory)
+                        .techStacks(List.of(unfilteredTechStack))
+                        .project(project)
+                        .clicks(4)
+                        .build()
+        );
+
+        repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .category(unfilteredArticleCategory)
+                        .techStacks(List.of(filteredTechStack))
+                        .project(project)
+                        .clicks(4)
+                        .build()
+        );
+
+        repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .category(filteredArticleCategory)
+                        .techStacks(List.of(filteredTechStack))
+                        .project(project)
+                        .clicks(6)
+                        .build()
+        );
+
+        Article articleClickRankFirst = repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .category(filteredArticleCategory)
+                        .techStacks(List.of(filteredTechStack))
+                        .project(project)
+                        .clicks(3)
+                        .build()
+        );
+
+        Article articleClickRankSecond = repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .category(filteredArticleCategory)
+                        .techStacks(List.of(filteredTechStack))
+                        .project(project)
+                        .clicks(2)
+                        .build()
+        );
+
+        Article articleRankThirdHasSmallId = repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .category(filteredArticleCategory)
+                        .techStacks(List.of(filteredTechStack))
+                        .project(project)
+                        .clicks(1)
+                        .build()
+        );
+
+        Article articleRankThirdHasBiggerId = repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .category(filteredArticleCategory)
+                        .techStacks(List.of(filteredTechStack))
+                        .project(project)
+                        .clicks(1)
+                        .build()
+        );
+
+        // when
+        ArticleResponse actualResponse = RestAssured.given().log().all()
+                .queryParams("sort", "clicks")
+                .queryParams("category", filteredArticleCategory.getName())
+                .queryParams("techStacks", List.of(filteredTechStack.getName()))
+                .queryParams("limit", 3)
+                .queryParams("cursor", "5_6")
+                .when().get("/articles")
+                .then().log().all()
+                .statusCode(200)
+                .extract().as(ArticleResponse.class);
+
+        // then
+        assertAll(
+                () -> assertThat(actualResponse.contents()).hasSize(3),
+                () -> assertThat(actualResponse.contents().getFirst().id()).isEqualTo(
+                        articleClickRankFirst.getId()),
+                () -> assertThat(actualResponse.contents().get(1).id()).isEqualTo(
+                        articleClickRankSecond.getId()),
+                () -> assertThat(actualResponse.contents().get(2).id()).isEqualTo(
+                        articleRankThirdHasBiggerId.getId())
+        );
+    }
+}

--- a/backend/src/test/java/moaon/backend/article/domain/ArticleSortByTest.java
+++ b/backend/src/test/java/moaon/backend/article/domain/ArticleSortByTest.java
@@ -1,0 +1,21 @@
+package moaon.backend.article.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class ArticleSortByTest {
+
+    @DisplayName("정렬 기준을 받아서 SortBy를 반환한다.")
+    @ParameterizedTest()
+    @CsvSource({"createdAt,CREATED_AT", "clicks,CLICKS", "createdat,CREATED_AT", ",CREATED_AT"})
+    void from(String sortType, ArticleSortBy expected) {
+        //when
+        ArticleSortBy actual = ArticleSortBy.from(sortType);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+}

--- a/backend/src/test/java/moaon/backend/article/dto/CreatedAtCursorTest.java
+++ b/backend/src/test/java/moaon/backend/article/dto/CreatedAtCursorTest.java
@@ -1,0 +1,23 @@
+package moaon.backend.article.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CreatedAtCursorTest {
+
+    @DisplayName("nextCursor를 포맷팅한다.")
+    @Test
+    void getNextCursor() {
+        // given
+        CreatedAtCursor cursor = new CreatedAtCursor(LocalDateTime.of(2024, 7, 31, 10, 0), 1L);
+
+        // when
+        String nextCursor = cursor.getNextCursor();
+
+        // then
+        assertThat(nextCursor).isEqualTo("2024-07-31T10:00:00_1");
+    }
+}

--- a/backend/src/test/java/moaon/backend/article/dto/CursorParserTest.java
+++ b/backend/src/test/java/moaon/backend/article/dto/CursorParserTest.java
@@ -1,0 +1,49 @@
+package moaon.backend.article.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.time.LocalDateTime;
+import moaon.backend.article.domain.ArticleSortBy;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CursorParserTest {
+
+    @DisplayName("마지막 날짜와 마지막 아이디를 바탕으로 CreatedAtCursor 를 만든다.")
+    @Test
+    void toCreatedAtCursor() {
+        // given
+        String cursor = "2024-07-31T10:00:00_12345";
+        ArticleSortBy sortBy = ArticleSortBy.CREATED_AT;
+
+        // when
+        Cursor<?> actual = CursorParser.toCursor(cursor, sortBy);
+
+        // then
+        assertAll(
+                () -> assertThat(actual).isInstanceOf(CreatedAtCursor.class),
+                () -> assertThat(actual.getLastId()).isEqualTo(12345),
+                () -> assertThat(actual.getSortValue()).isEqualTo(LocalDateTime.of(2024, 7, 31, 10, 0))
+        );
+    }
+
+    @DisplayName("마지막 클릭수와 마지막 아이디를 바탕으로 ClickCursor 를 만든다.")
+    @Test
+    void toClickCursor() {
+        // given
+        String cursor = "1500_12345";
+        ArticleSortBy sortBy = ArticleSortBy.CLICKS;
+
+        // when
+        Cursor<?> actual = CursorParser.toCursor(cursor, sortBy);
+
+        // then
+        assertAll(
+                () -> assertThat(actual).isInstanceOf(ClickCursor.class),
+                () -> assertThat(actual.getLastId()).isEqualTo(12345),
+                () -> assertThat(actual.getSortValue()).isEqualTo(1500)
+        );
+    }
+
+}

--- a/backend/src/test/java/moaon/backend/article/dto/CursorParserTest.java
+++ b/backend/src/test/java/moaon/backend/article/dto/CursorParserTest.java
@@ -45,5 +45,4 @@ class CursorParserTest {
                 () -> assertThat(actual.getSortValue()).isEqualTo(1500)
         );
     }
-
 }

--- a/backend/src/test/java/moaon/backend/article/repository/CustomizedArticleRepositoryImplTest.java
+++ b/backend/src/test/java/moaon/backend/article/repository/CustomizedArticleRepositoryImplTest.java
@@ -1,0 +1,355 @@
+package moaon.backend.article.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import moaon.backend.article.domain.Article;
+import moaon.backend.article.domain.ArticleCategory;
+import moaon.backend.article.dto.ArticleQueryCondition;
+import moaon.backend.fixture.ArticleFixtureBuilder;
+import moaon.backend.fixture.Fixture;
+import moaon.backend.fixture.RepositoryHelper;
+import moaon.backend.global.config.QueryDslConfig;
+import moaon.backend.techStack.domain.TechStack;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import({RepositoryHelper.class, QueryDslConfig.class})
+class CustomizedArticleRepositoryImplTest {
+
+    @Autowired
+    private CustomizedArticleRepositoryImpl customizedArticleRepository;
+
+    @Autowired
+    private RepositoryHelper repositoryHelper;
+
+    @Autowired
+    private CustomizedArticleRepositoryImpl customizedArticleRepositoryImpl;
+
+    @DisplayName("카테고리 필터를 이용하여 아티클을 조회한다.")
+    @Test
+    void findWithCategoryFilter() {
+        // given
+        ArticleCategory articleCategory1 = Fixture.anyArticleCategory();
+        ArticleCategory articleCategory2 = Fixture.anyArticleCategory();
+
+        Article articleWithCategory = repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .category(articleCategory1)
+                        .createdAt(LocalDateTime.of(2024, 7, 30, 0, 0))
+                        .build()
+        );
+
+        repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .category(articleCategory2)
+                        .build()
+        );
+
+        ArticleQueryCondition queryCondition = ArticleQueryCondition.from(
+                null,
+                articleCategory1.getName(),
+                List.of(),
+                "createdAt",
+                10,
+                "2024-07-31T10:00:00_0"
+        );
+
+        // when
+        List<Article> articles = customizedArticleRepository.findWithSearchConditions(queryCondition);
+
+        // then
+        assertThat(articles).containsOnlyOnce(articleWithCategory);
+    }
+
+    @DisplayName("기술스택 필터를 이용하여 아티클을 조회한다.")
+    @Test
+    void findWithTechStackFilter() {
+        // given
+        TechStack techStack1 = Fixture.anyTechStack();
+        TechStack techStack2 = Fixture.anyTechStack();
+
+        Article articleWithTechStacks = repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .techStacks(List.of(techStack1, techStack2))
+                        .createdAt(LocalDateTime.of(2024, 7, 30, 0, 0))
+                        .build()
+        );
+
+        repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .techStacks(List.of(techStack2))
+                        .build()
+        );
+
+        ArticleQueryCondition queryCondition = ArticleQueryCondition.from(
+                null,
+                null,
+                List.of(techStack1.getName(), techStack2.getName()),
+                "createdAt",
+                10,
+                "2024-07-31T10:00:00_1"
+        );
+
+        // when
+        List<Article> articles = customizedArticleRepository.findWithSearchConditions(queryCondition);
+
+        // then
+        assertThat(articles).containsOnlyOnce(articleWithTechStacks);
+    }
+
+    @DisplayName("카테고리, 기술스택 필터를 이용하여 아티클을 조회한다.")
+    @Test
+    void findWithTechStackAndCategoryFilter() {
+        // given
+        TechStack techStack1 = Fixture.anyTechStack();
+        TechStack techStack2 = Fixture.anyTechStack();
+
+        ArticleCategory articleCategory = Fixture.anyArticleCategory();
+
+        Article articleWithTechStacksAndCategory = repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .techStacks(List.of(techStack1, techStack2))
+                        .category(articleCategory)
+                        .createdAt(LocalDateTime.of(2024, 7, 30, 0, 0))
+                        .build()
+        );
+
+        repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .techStacks(List.of(techStack2))
+                        .category(articleCategory)
+                        .build()
+        );
+
+        ArticleQueryCondition queryCondition = ArticleQueryCondition.from(
+                null,
+                articleCategory.getName(),
+                List.of(techStack1.getName(), techStack2.getName()),
+                "createdAt",
+                10,
+                "2024-07-31T10:00:00_1"
+        );
+
+        // when
+        List<Article> articles = customizedArticleRepository.findWithSearchConditions(queryCondition);
+
+        // then
+        assertThat(articles).containsOnlyOnce(articleWithTechStacksAndCategory);
+    }
+
+    @DisplayName("아티클을 생성일자를 기준으로 정렬한다.")
+    @Test
+    void toOrderByCreatedAt() {
+        // given
+        LocalDateTime today = LocalDateTime.of(2024, 7, 29, 0, 0);
+        LocalDateTime tomorrow = today.plusDays(1);
+        LocalDateTime yesterday = today.minusDays(1);
+
+        Article todayArticle = repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .createdAt(today)
+                        .build()
+        );
+
+        Article yesterdayArticle = repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .createdAt(yesterday)
+                        .build()
+        );
+
+        Article tomorrowArticle = repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .createdAt(tomorrow)
+                        .build()
+        );
+
+        repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .createdAt(LocalDateTime.of(2024, 7, 31, 10, 0, 0))
+                        .build()
+        );
+
+        ArticleQueryCondition queryCondition = ArticleQueryCondition.from(
+                null,
+                null,
+                null,
+                "createdAt",
+                10,
+                "2024-07-31T10:00:00_1"
+        );
+
+        // when
+        List<Article> articles = customizedArticleRepository.findWithSearchConditions(queryCondition);
+
+        // then
+        assertThat(articles).containsExactly(tomorrowArticle, todayArticle, yesterdayArticle);
+    }
+
+    @DisplayName("아티클을 클릭수 기준으로 정렬한다.")
+    @Test
+    void toOrderByClicks() {
+        // given
+        Article highClicks = repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .clicks(3)
+                        .build()
+        );
+
+        Article middleClicks = repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .clicks(2)
+                        .build()
+        );
+
+        Article lowClicks = repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .clicks(1)
+                        .build()
+        );
+
+        repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .clicks(5)
+                        .build()
+        );
+
+        repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .clicks(4)
+                        .build()
+        );
+
+        ArticleQueryCondition queryCondition = ArticleQueryCondition.from(
+                null,
+                null,
+                null,
+                "clicks",
+                10,
+                "4_4"
+        );
+
+        // when
+        List<Article> articles = customizedArticleRepositoryImpl.findWithSearchConditions(queryCondition);
+
+        // then
+        assertThat(articles).containsExactly(highClicks, middleClicks, lowClicks);
+    }
+
+    @DisplayName("마지막 페이지가 아닐 시 limit + 1개 만큼 가져온다.")
+    @Test
+    void findArticlesForLimitPlusOne() {
+        // given
+        repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .clicks(3)
+                        .build()
+        );
+
+        repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .clicks(3)
+                        .build()
+        );
+
+        repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .clicks(3)
+                        .build()
+        );
+
+        repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .clicks(3)
+                        .build()
+        );
+
+        repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .clicks(3)
+                        .build()
+        );
+
+        repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .clicks(3)
+                        .build()
+        );
+
+        ArticleQueryCondition queryCondition = ArticleQueryCondition.from(
+                null,
+                null,
+                null,
+                "clicks",
+                4,
+                "4_9999999"
+        );
+
+        // when
+        List<Article> articles = customizedArticleRepository.findWithSearchConditions(queryCondition);
+
+        // then
+        assertThat(articles).hasSize(5);
+    }
+
+    @DisplayName("마지막 페이지 도달하면 limit 개수 이하로 가져온다.")
+    @Test
+    void findArticlesForUnderLimit() {
+        // given
+        repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .clicks(3)
+                        .build()
+        );
+
+        repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .clicks(3)
+                        .build()
+        );
+
+        repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .clicks(3)
+                        .build()
+        );
+
+        repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .clicks(3)
+                        .build()
+        );
+
+        repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .clicks(3)
+                        .build()
+        );
+
+        repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .clicks(3)
+                        .build()
+        );
+
+        ArticleQueryCondition queryCondition = ArticleQueryCondition.from(
+                null,
+                null,
+                null,
+                "clicks",
+                9,
+                "4_9999999"
+        );
+
+        // when
+        List<Article> articles = customizedArticleRepository.findWithSearchConditions(queryCondition);
+
+        // then
+        assertThat(articles).hasSize(6);
+    }
+}

--- a/backend/src/test/java/moaon/backend/article/repository/CustomizedArticleRepositoryImplTest.java
+++ b/backend/src/test/java/moaon/backend/article/repository/CustomizedArticleRepositoryImplTest.java
@@ -35,25 +35,25 @@ class CustomizedArticleRepositoryImplTest {
     @Test
     void findWithCategoryFilter() {
         // given
-        ArticleCategory articleCategory1 = Fixture.anyArticleCategory();
-        ArticleCategory articleCategory2 = Fixture.anyArticleCategory();
+        ArticleCategory filterdArticleCategory = Fixture.anyArticleCategory();
+        ArticleCategory unFilterdArticleCategory = Fixture.anyArticleCategory();
 
         Article articleWithCategory = repositoryHelper.save(
                 new ArticleFixtureBuilder()
-                        .category(articleCategory1)
+                        .category(filterdArticleCategory)
                         .createdAt(LocalDateTime.of(2024, 7, 30, 0, 0))
                         .build()
         );
 
         repositoryHelper.save(
                 new ArticleFixtureBuilder()
-                        .category(articleCategory2)
+                        .category(unFilterdArticleCategory)
                         .build()
         );
 
         ArticleQueryCondition queryCondition = ArticleQueryCondition.from(
                 null,
-                articleCategory1.getName(),
+                filterdArticleCategory.getName(),
                 List.of(),
                 "createdAt",
                 10,

--- a/backend/src/test/java/moaon/backend/article/service/ArticleServiceTest.java
+++ b/backend/src/test/java/moaon/backend/article/service/ArticleServiceTest.java
@@ -1,0 +1,136 @@
+package moaon.backend.article.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.List;
+import moaon.backend.article.domain.Article;
+import moaon.backend.article.domain.ArticleSortBy;
+import moaon.backend.article.dto.ArticleQueryCondition;
+import moaon.backend.article.dto.ArticleResponse;
+import moaon.backend.article.dto.Content;
+import moaon.backend.article.dto.Cursor;
+import moaon.backend.article.dto.CursorParser;
+import moaon.backend.article.repository.ArticleRepository;
+import moaon.backend.fixture.ArticleFixtureBuilder;
+import moaon.backend.fixture.ProjectFixtureBuilder;
+import moaon.backend.project.domain.Project;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ArticleServiceTest {
+
+    @Mock
+    private ArticleRepository articleRepository;
+
+    @InjectMocks
+    private ArticleService articleService;
+
+    @DisplayName("다음 아티클이 존재할 때 nextCursor를 포함하여 아티클을 리턴한다.")
+    @Test
+    void getPagedArticlesWhenHasNext() {
+        // given
+        Project project = new ProjectFixtureBuilder().build();
+        Article article1 = new ArticleFixtureBuilder()
+                .id(1L)
+                .project(project)
+                .build();
+        Article article2 = new ArticleFixtureBuilder()
+                .id(2L)
+                .project(project)
+                .build();
+        Article article3 = new ArticleFixtureBuilder()
+                .id(3L)
+                .project(project)
+                .build();
+        List<Article> articles = List.of(article1, article2, article3);
+
+        Cursor<?> cursor = CursorParser.toCursor(article3, ArticleSortBy.CREATED_AT);
+
+        Mockito.when(articleRepository.findWithSearchConditions(Mockito.any()))
+                .thenReturn(articles);
+
+        Mockito.when(articleRepository.count()).thenReturn(5L);
+
+        ArticleQueryCondition articleQueryCondition = new ArticleQueryCondition(
+                null,
+                null,
+                null,
+                ArticleSortBy.CREATED_AT,
+                2,
+                null
+        );
+
+        Content content1 = Content.from(article1);
+        Content content2 = Content.from(article2);
+
+        // when
+        ArticleResponse actual = articleService.getPagedArticles(articleQueryCondition);
+
+        // then
+        assertAll(
+                () -> assertThat(actual.contents()).hasSize(2),
+                () -> assertThat(actual.contents().get(0)).isEqualTo(content1),
+                () -> assertThat(actual.contents().get(1)).isEqualTo(content2),
+                () -> assertThat(actual.hasNext()).isTrue(),
+                () -> assertThat(actual.nextCursor()).isEqualTo(cursor.getNextCursor())
+        );
+    }
+
+    @DisplayName("다음 아티클이 존재하지 않다면 nextCursor 에 공백을 넣고 리턴한다.")
+    @Test
+    void getPagedArticlesWhenHasNoNext() {
+        // given
+        Project project = new ProjectFixtureBuilder().build();
+        Article article1 = new ArticleFixtureBuilder()
+                .id(1L)
+                .project(project)
+                .build();
+        Article article2 = new ArticleFixtureBuilder()
+                .id(2L)
+                .project(project)
+                .build();
+        Article article3 = new ArticleFixtureBuilder()
+                .id(3L)
+                .project(project)
+                .build();
+        List<Article> articles = List.of(article1, article2, article3);
+        
+        Mockito.when(articleRepository.findWithSearchConditions(Mockito.any()))
+                .thenReturn(articles);
+
+        Mockito.when(articleRepository.count()).thenReturn(5L);
+
+        ArticleQueryCondition articleQueryCondition = new ArticleQueryCondition(
+                null,
+                null,
+                null,
+                ArticleSortBy.CREATED_AT,
+                3,
+                null
+        );
+
+        Content content1 = Content.from(article1);
+        Content content2 = Content.from(article2);
+        Content content3 = Content.from(article3);
+
+        // when
+        ArticleResponse actual = articleService.getPagedArticles(articleQueryCondition);
+
+        // then
+        assertAll(
+                () -> assertThat(actual.contents()).hasSize(3),
+                () -> assertThat(actual.contents().get(0)).isEqualTo(content1),
+                () -> assertThat(actual.contents().get(1)).isEqualTo(content2),
+                () -> assertThat(actual.contents().get(2)).isEqualTo(content3),
+                () -> assertThat(actual.hasNext()).isFalse(),
+                () -> assertThat(actual.nextCursor()).isEqualTo("")
+        );
+    }
+}

--- a/backend/src/test/java/moaon/backend/article/service/ArticleServiceTest.java
+++ b/backend/src/test/java/moaon/backend/article/service/ArticleServiceTest.java
@@ -75,9 +75,7 @@ class ArticleServiceTest {
 
         // then
         assertAll(
-                () -> assertThat(actual.articleContents()).hasSize(2),
-                () -> assertThat(actual.articleContents().get(0)).isEqualTo(articleContent1),
-                () -> assertThat(actual.articleContents().get(1)).isEqualTo(articleContent2),
+                () -> assertThat(actual.articleContents()).containsExactly(articleContent1, articleContent2),
                 () -> assertThat(actual.hasNext()).isTrue(),
                 () -> assertThat(actual.nextCursor()).isEqualTo(cursor.getNextCursor())
         );
@@ -125,10 +123,8 @@ class ArticleServiceTest {
 
         // then
         assertAll(
-                () -> assertThat(actual.articleContents()).hasSize(3),
-                () -> assertThat(actual.articleContents().get(0)).isEqualTo(articleContent1),
-                () -> assertThat(actual.articleContents().get(1)).isEqualTo(articleContent2),
-                () -> assertThat(actual.articleContents().get(2)).isEqualTo(articleContent3),
+                () -> assertThat(actual.articleContents()).containsExactly(articleContent1, articleContent2,
+                        articleContent3),
                 () -> assertThat(actual.hasNext()).isFalse(),
                 () -> assertThat(actual.nextCursor()).isNull()
         );

--- a/backend/src/test/java/moaon/backend/article/service/ArticleServiceTest.java
+++ b/backend/src/test/java/moaon/backend/article/service/ArticleServiceTest.java
@@ -130,7 +130,7 @@ class ArticleServiceTest {
                 () -> assertThat(actual.articleContents().get(1)).isEqualTo(articleContent2),
                 () -> assertThat(actual.articleContents().get(2)).isEqualTo(articleContent3),
                 () -> assertThat(actual.hasNext()).isFalse(),
-                () -> assertThat(actual.nextCursor()).isEqualTo("")
+                () -> assertThat(actual.nextCursor()).isNull()
         );
     }
 }

--- a/backend/src/test/java/moaon/backend/article/service/ArticleServiceTest.java
+++ b/backend/src/test/java/moaon/backend/article/service/ArticleServiceTest.java
@@ -6,9 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import java.util.List;
 import moaon.backend.article.domain.Article;
 import moaon.backend.article.domain.ArticleSortBy;
+import moaon.backend.article.dto.ArticleContent;
 import moaon.backend.article.dto.ArticleQueryCondition;
 import moaon.backend.article.dto.ArticleResponse;
-import moaon.backend.article.dto.Content;
 import moaon.backend.article.dto.Cursor;
 import moaon.backend.article.dto.CursorParser;
 import moaon.backend.article.repository.ArticleRepository;
@@ -67,17 +67,17 @@ class ArticleServiceTest {
                 null
         );
 
-        Content content1 = Content.from(article1);
-        Content content2 = Content.from(article2);
+        ArticleContent articleContent1 = ArticleContent.from(article1);
+        ArticleContent articleContent2 = ArticleContent.from(article2);
 
         // when
         ArticleResponse actual = articleService.getPagedArticles(articleQueryCondition);
 
         // then
         assertAll(
-                () -> assertThat(actual.contents()).hasSize(2),
-                () -> assertThat(actual.contents().get(0)).isEqualTo(content1),
-                () -> assertThat(actual.contents().get(1)).isEqualTo(content2),
+                () -> assertThat(actual.articleContents()).hasSize(2),
+                () -> assertThat(actual.articleContents().get(0)).isEqualTo(articleContent1),
+                () -> assertThat(actual.articleContents().get(1)).isEqualTo(articleContent2),
                 () -> assertThat(actual.hasNext()).isTrue(),
                 () -> assertThat(actual.nextCursor()).isEqualTo(cursor.getNextCursor())
         );
@@ -101,7 +101,7 @@ class ArticleServiceTest {
                 .project(project)
                 .build();
         List<Article> articles = List.of(article1, article2, article3);
-        
+
         Mockito.when(articleRepository.findWithSearchConditions(Mockito.any()))
                 .thenReturn(articles);
 
@@ -116,19 +116,19 @@ class ArticleServiceTest {
                 null
         );
 
-        Content content1 = Content.from(article1);
-        Content content2 = Content.from(article2);
-        Content content3 = Content.from(article3);
+        ArticleContent articleContent1 = ArticleContent.from(article1);
+        ArticleContent articleContent2 = ArticleContent.from(article2);
+        ArticleContent articleContent3 = ArticleContent.from(article3);
 
         // when
         ArticleResponse actual = articleService.getPagedArticles(articleQueryCondition);
 
         // then
         assertAll(
-                () -> assertThat(actual.contents()).hasSize(3),
-                () -> assertThat(actual.contents().get(0)).isEqualTo(content1),
-                () -> assertThat(actual.contents().get(1)).isEqualTo(content2),
-                () -> assertThat(actual.contents().get(2)).isEqualTo(content3),
+                () -> assertThat(actual.articleContents()).hasSize(3),
+                () -> assertThat(actual.articleContents().get(0)).isEqualTo(articleContent1),
+                () -> assertThat(actual.articleContents().get(1)).isEqualTo(articleContent2),
+                () -> assertThat(actual.articleContents().get(2)).isEqualTo(articleContent3),
                 () -> assertThat(actual.hasNext()).isFalse(),
                 () -> assertThat(actual.nextCursor()).isEqualTo("")
         );

--- a/backend/src/test/java/moaon/backend/fixture/ArticleFixtureBuilder.java
+++ b/backend/src/test/java/moaon/backend/fixture/ArticleFixtureBuilder.java
@@ -1,0 +1,78 @@
+package moaon.backend.fixture;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import moaon.backend.article.domain.Article;
+import moaon.backend.article.domain.ArticleCategory;
+import moaon.backend.project.domain.Project;
+import moaon.backend.techStack.domain.TechStack;
+
+public class ArticleFixtureBuilder {
+
+    private Long id;
+    private String title;
+    private String summary;
+    private String content;
+    private String articleUrl;
+    private LocalDateTime createdAt;
+    private Project project;
+    private ArticleCategory category;
+    private List<TechStack> techStacks;
+    private int clicks = 0;
+
+    public ArticleFixtureBuilder() {
+        this.title = Fixture.nameWithSequence("테스트 아티클 제목");
+        this.summary = Fixture.nameWithSequence("테스트 아티클 요약");
+        this.content = Fixture.nameWithSequence("테스트 아티클 본문");
+        this.articleUrl = "https://test-product.com";
+        this.createdAt = LocalDateTime.now();
+        this.techStacks = new ArrayList<>(List.of(Fixture.anyTechStack()));
+        this.category = Fixture.anyArticleCategory();
+    }
+
+    public ArticleFixtureBuilder id(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    public ArticleFixtureBuilder techStacks(List<TechStack> techStacks) {
+        this.techStacks = techStacks;
+        return this;
+    }
+
+    public ArticleFixtureBuilder category(ArticleCategory category) {
+        this.category = category;
+        return this;
+    }
+
+    public ArticleFixtureBuilder project(Project project) {
+        this.project = project;
+        return this;
+    }
+
+    public ArticleFixtureBuilder createdAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+
+    public ArticleFixtureBuilder clicks(int clicks) {
+        this.clicks = clicks;
+        return this;
+    }
+
+    public Article build() {
+        return Article.builder()
+                .id(this.id)
+                .title(this.title)
+                .summary(this.summary)
+                .content(this.content)
+                .articleUrl(this.articleUrl)
+                .clicks(this.clicks)
+                .createdAt(this.createdAt)
+                .project(this.project)
+                .category(this.category)
+                .techStacks(this.techStacks)
+                .build();
+    }
+}

--- a/backend/src/test/java/moaon/backend/fixture/Fixture.java
+++ b/backend/src/test/java/moaon/backend/fixture/Fixture.java
@@ -1,6 +1,7 @@
 package moaon.backend.fixture;
 
 import java.util.concurrent.atomic.AtomicLong;
+import moaon.backend.article.domain.ArticleCategory;
 import moaon.backend.member.domain.Member;
 import moaon.backend.project.domain.ProjectCategory;
 import moaon.backend.techStack.domain.TechStack;
@@ -19,6 +20,10 @@ public class Fixture {
 
     public static ProjectCategory anyProjectCategory() {
         return new ProjectCategory(nameWithSequence("카테고리"));
+    }
+
+    public static ArticleCategory anyArticleCategory() {
+        return new ArticleCategory(nameWithSequence("아티클 카테고리"));
     }
 
     protected static String nameWithSequence(String name) {

--- a/backend/src/test/java/moaon/backend/fixture/RepositoryHelper.java
+++ b/backend/src/test/java/moaon/backend/fixture/RepositoryHelper.java
@@ -1,5 +1,8 @@
 package moaon.backend.fixture;
 
+import moaon.backend.article.domain.Article;
+import moaon.backend.article.repository.ArticleCategoryRepository;
+import moaon.backend.article.repository.ArticleRepository;
 import moaon.backend.member.repository.MemberRepository;
 import moaon.backend.project.domain.Project;
 import moaon.backend.project.repository.ProjectCategoryRepository;
@@ -21,7 +24,13 @@ public class RepositoryHelper {
     private ProjectCategoryRepository projectCategoryRepository;
 
     @Autowired
+    private ArticleCategoryRepository articleCategoryRepository;
+
+    @Autowired
     private ProjectRepository projectRepository;
+
+    @Autowired
+    private ArticleRepository articleRepository;
 
     public Project save(Project project) {
         memberRepository.save(project.getAuthor());
@@ -29,5 +38,12 @@ public class RepositoryHelper {
         projectCategoryRepository.saveAll(project.getCategories());
 
         return projectRepository.save(project);
+    }
+
+    public Article save(Article article) {
+        articleCategoryRepository.save(article.getCategory());
+        techStackRepository.saveAll(article.getTechStacks());
+
+        return articleRepository.save(article);
     }
 }


### PR DESCRIPTION
# 🎯 이슈 번호

close #111

## ✅ 체크 리스트

- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 🏁 작업 내용

- 기존의 Project 조회는 연관된 Article/TechStack 조건을 만족하는지 확인하기 위해 모든 Project를 조회한 뒤, 연관 테이블 조건을 만족하는지 `EXISTS` 쿼리로 필터링했습니다.  
  Article 조회에서 다음과 같이 개선했습니다.

  (1). **Article-Category 조인**  
    - `Article` 테이블과 `ArticleCategory` 테이블을 조인합니다.  
    - 이후 카테고리 이름이 필터 조건과 일치하는지 `where` 절에서 필터링합니다.

  (2). **Article-TechStack 조인**  
    - `Article`과 `TechStack` 테이블을 조인합니다.  
    - 이때 조인되는 `TechStack`은 **필터로 선택된 기술스택 이름들에 한정**됩니다.

  (3). **카테고리 필터**  
    - 조인된 `articleCategory.name`이 사용자가 선택한 필터 값과 정확히 일치하는 경우만 조회됩니다.

  (4). **기술스택 필터 (전부 포함)**  
    - 단순히 포함 여부(`IN`)가 아닌, **필터에 포함된 모든 기술스택이 전부 포함**되어야 합니다.  
    - 이를 위해 `techStack.name.countDistinct()`이 사용되며, 개수가 필터 조건과 일치하는 경우만 반환합니다.

  (5). **커서 기반 페이지네이션**  
    - 커서로 전달된 값이 `createdAt` 또는 `clicks`일 경우, 다음과 같은 조건을 적용합니다:  
      - `sortValue`보다 작으면 그대로 포함  
      - `sortValue`가 동일할 경우 `id` 기준으로 더 작은 값만 포함 (안정적인 정렬 유지)

  (6). **정렬 기준**  
    - 선택된 정렬 기준에 따라 정렬합니다.  
    - `clicks` 기준이면 `(clicks DESC, id DESC)`, `createdAt`이면 `(createdAt DESC, id DESC)`로 정렬하여 **복합 인덱스 활용이 가능**하도록 설계합니다.

  (7). **`limit + 1` 조회**  
    - 실제 사용자에게 보여줄 개수보다 1개 더 조회하여 **hasNext 페이지 유무를 판단**합니다.  
    - 만약 조회된 데이터가 `limit` 이하라면 다음 페이지는 없는 것으로 간주합니다.

  논리의 흐름이 복잡하기에 메서드 분리는 안했습니다. 이후 리뷰에서는 적절히 분리하겠습니다.

---

- Cursor 는 createdAt 또는 Clicks 를 모두 대비해야 합니다. 따라서 제네릭을 활용하여 추상화했습니다.  
  (1) 타입 안정성 확보를 위해 제네릭을 사용했습니다.  
  (2) 다만, `applyCursor()`에서 캐스팅이 필요해졌습니다.  
  더 좋은 방식이 있다면 알려주세요

---

- Article @Builder 허용  
  테스트에서 `Article`의 id가 필요한 상황이 있어 DTO 변환을 위해 엔티티에 `@Builder`를 열었습니다.  
  이 부분이 더 깔끔하게 해결될 수 있다면 의견 부탁드립니다.
  
---

- hasNext 가 없을 경우 nextCursor 를 "" 로 주고 있습니다.
null 과 "" 중에 뭐가 좋을 지 논의하면 좋을 것 같습니다.

---

- 각종 네이밍 관련 피드백 주세요.

## 🎸 기타

- 생각보다 구현 범위가 넓어 놓친 테스트가 있을 수 있습니다. 최대한 꼼꼼하게 작성했지만,  
  추가되었으면 하는 테스트나 이상한 부분이 있다면 알려주세요. 🙇‍♂️
