### PR TITLE
feat(BE): AWS CloudWatch 로깅 드라이버 추가

### DIFF
--- a/backend/compose.yaml
+++ b/backend/compose.yaml
@@ -29,6 +29,12 @@ services:
         condition: service_healthy
     ports:
       - "8080:8080"
+    logging:
+      driver: "awslogs"
+      options:
+        awslogs-group: "moaon"
+        awslogs-region: "ap-northeast-2"
+        awslogs-stream: "dev-docker"
     environment:
       SPRING_PROFILES_ACTIVE: dev
       SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL_DEV}


### PR DESCRIPTION
# 🎯 이슈 번호

- close #156 

## ✅ 체크 리스트

- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 🏁 작업 내용

- 도커 컨테이너의 로깅을 알아서 AWS CloudWatch로 전송해주는 설정을 추가했습니다
- 정상 작동하는거 개발 서버에서 확인했습니다!
- 이 로깅 기록이 컨테이너가 초기화되도 CloudWatch에서 보관해주는지, 아니면 날아가는지는 확인해 봐야할 것 같습니다. 만약 안날아가면 로깅을 굳이 직접 파일로 관리하지 않아도 될 듯..?! 일단 써보고 판단해볼게요 도커 짱짱

## 🎸 기타

- https://docs.docker.com/engine/logging/drivers/awslogs/#amazon-cloudwatch-logs-options
- [Cloud Watch 로그 그룹](https://ap-northeast-2.console.aws.amazon.com/cloudwatch/home?region=ap-northeast-2#logsV2:log-groups/log-group/moaon/log-events/dev-docker) (로그 수집되는 위치)
- [Cloud Watch 모니터링 대시보드](https://ap-northeast-2.console.aws.amazon.com/cloudwatch/home?region=ap-northeast-2#dashboards/dashboard/DASHBOARD-moaon-dev): 메트릭 구성 완료, 로깅 구성 중
