### PR TITLE
feat(BE): 아티클 클릭 조회수 추가 기능 구현

### DIFF
--- a/backend/src/main/java/moaon/backend/article/controller/ArticleController.java
+++ b/backend/src/main/java/moaon/backend/article/controller/ArticleController.java
@@ -1,13 +1,19 @@
 package moaon.backend.article.controller;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 import moaon.backend.article.dto.ArticleQueryCondition;
 import moaon.backend.article.dto.ArticleResponse;
 import moaon.backend.article.service.ArticleService;
+import moaon.backend.global.cookie.AccessHistory;
 import moaon.backend.global.cookie.TrackingCookieManager;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -46,5 +52,20 @@ public class ArticleController {
         );
 
         return ResponseEntity.ok(articleService.getPagedArticles(queryCondition));
+    }
+
+    @PostMapping("/{id}/clicks")
+    public ResponseEntity<Void> updateArticleClicks(
+            @PathVariable("id") long id,
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
+        AccessHistory accessHistory = cookieManager.extractViewedMap(request);
+        if (cookieManager.isCountIncreasable(id, accessHistory)) {
+            articleService.increaseClicksCount(id);
+            Cookie cookie = cookieManager.createOrUpdateCookie(id, accessHistory);
+            response.addCookie(cookie);
+        }
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/moaon/backend/article/controller/ArticleController.java
+++ b/backend/src/main/java/moaon/backend/article/controller/ArticleController.java
@@ -1,10 +1,11 @@
 package moaon.backend.article.controller;
 
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import moaon.backend.article.dto.ArticleQueryCondition;
 import moaon.backend.article.dto.ArticleResponse;
 import moaon.backend.article.service.ArticleService;
+import moaon.backend.global.cookie.TrackingCookieManager;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,10 +14,18 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/articles")
-@RequiredArgsConstructor
 public class ArticleController {
 
+    private final TrackingCookieManager cookieManager;
     private final ArticleService articleService;
+
+    public ArticleController(
+            @Qualifier("articleClickCookieManager") TrackingCookieManager cookieManager,
+            ArticleService articleService
+    ) {
+        this.cookieManager = cookieManager;
+        this.articleService = articleService;
+    }
 
     @GetMapping
     public ResponseEntity<ArticleResponse> getPagedArticles(

--- a/backend/src/main/java/moaon/backend/article/domain/Article.java
+++ b/backend/src/main/java/moaon/backend/article/domain/Article.java
@@ -93,4 +93,8 @@ public class Article extends BaseTimeEntity {
     public List<TechStack> getTechStacks() {
         return List.copyOf(techStacks);
     }
+
+    public void addClickCount() {
+        clicks++;
+    }
 }

--- a/backend/src/main/java/moaon/backend/article/service/ArticleService.java
+++ b/backend/src/main/java/moaon/backend/article/service/ArticleService.java
@@ -49,4 +49,11 @@ public class ArticleService {
         List<Article> articles = articleRepository.findAllByProjectId(id);
         return ArticleDetailResponse.from(articles);
     }
+
+    @Transactional
+    public void increaseClicksCount(long id) {
+        Article article = articleRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.ARTICLE_NOT_FOUND));
+        article.addClickCount();
+    }
 }

--- a/backend/src/main/java/moaon/backend/global/config/CookieConfig.java
+++ b/backend/src/main/java/moaon/backend/global/config/CookieConfig.java
@@ -1,14 +1,23 @@
 package moaon.backend.global.config;
 
-import moaon.backend.global.cookie.ProjectViewCookieManager;
+import moaon.backend.global.cookie.TrackingCookieManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class CookieConfig {
+    private static final String PROJECT_COOKIE_NAME = "viewed_projects";
+    private static final String PROJECT_COOKIE_PATH = "/projects";
+    private static final String ARTICLE_COOKIE_NAME = "clicked_articles";
+    private static final String ARTICLE_COOKIE_PATH = "/articles";
 
     @Bean
-    public ProjectViewCookieManager projectViewCookieManager() {
-        return new ProjectViewCookieManager();
+    public TrackingCookieManager projectViewCookieManager() {
+        return new TrackingCookieManager(PROJECT_COOKIE_NAME, PROJECT_COOKIE_PATH);
+    }
+
+    @Bean
+    public TrackingCookieManager articleClickCookieManager() {
+        return new TrackingCookieManager(ARTICLE_COOKIE_NAME, ARTICLE_COOKIE_PATH);
     }
 }

--- a/backend/src/main/java/moaon/backend/global/cookie/AccessHistory.java
+++ b/backend/src/main/java/moaon/backend/global/cookie/AccessHistory.java
@@ -12,7 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @RequiredArgsConstructor
 @Slf4j
-public class ProjectViewTimes {
+public class AccessHistory {
 
     private static final int MAX_ENTRIES = 50;
     private static final int BLOCK_SECONDS = 60 * 30;
@@ -21,10 +21,10 @@ public class ProjectViewTimes {
 
     private final Map<Long, Long> projectViewTimes;
 
-    public static ProjectViewTimes from(String decodedCookieValue) {
+    public static AccessHistory from(String decodedCookieValue) {
         Map<String, Long> viewedMap = parseJson(decodedCookieValue);
         Map<Long, Long> result = convertKeysToLong(viewedMap);
-        return new ProjectViewTimes(result);
+        return new AccessHistory(result);
     }
 
     private static Map<String, Long> parseJson(String decodedCookieValue) {
@@ -49,15 +49,15 @@ public class ProjectViewTimes {
         return result;
     }
 
-    public static ProjectViewTimes empty() {
-        return new ProjectViewTimes(new HashMap<>());
+    public static AccessHistory empty() {
+        return new AccessHistory(new HashMap<>());
     }
 
     public void removeExpiredEntries(long currentTimeSeconds) {
         this.projectViewTimes.entrySet().removeIf(entry -> currentTimeSeconds - entry.getValue() >= BLOCK_SECONDS);
     }
 
-    public boolean isViewCountIncreasable(long projectId, long currentTimeSeconds) {
+    public boolean isCountIncreasable(long projectId, long currentTimeSeconds) {
         Long lastViewTime = this.projectViewTimes.get(projectId);
         return lastViewTime == null || currentTimeSeconds - lastViewTime >= BLOCK_SECONDS;
     }

--- a/backend/src/main/java/moaon/backend/global/cookie/TrackingCookieManager.java
+++ b/backend/src/main/java/moaon/backend/global/cookie/TrackingCookieManager.java
@@ -9,59 +9,61 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+@RequiredArgsConstructor
 @Slf4j
-public class ProjectViewCookieManager {
+public class TrackingCookieManager {
 
-    private static final String COOKIE_NAME = "viewed_projects";
-    private static final String COOKIE_PATH = "/projects";
+    private final String cookieName;
+    private final String cookiePath;
 
-    public ProjectViewTimes extractViewedMap(HttpServletRequest request) {
+    public AccessHistory extractViewedMap(HttpServletRequest request) {
         Cookie cookie = getCookie(request);
         if (cookie == null) {
-            return ProjectViewTimes.empty();
+            return AccessHistory.empty();
         }
         String decodedCookieValue = URLDecoder.decode(cookie.getValue(), StandardCharsets.UTF_8);
 
-        ProjectViewTimes projectViewTimes = ProjectViewTimes.from(decodedCookieValue);
-        projectViewTimes.removeExpiredEntries(getCurrentTimeSeconds());
-        return projectViewTimes;
+        AccessHistory accessHistory = AccessHistory.from(decodedCookieValue);
+        accessHistory.removeExpiredEntries(getCurrentTimeSeconds());
+        return accessHistory;
     }
 
-    public boolean isViewCountIncreasable(long projectId, ProjectViewTimes projectViewTimes) {
+    public boolean isCountIncreasable(long projectId, AccessHistory accessHistory) {
         long currentTimeSeconds = getCurrentTimeSeconds();
-        return projectViewTimes.isViewCountIncreasable(projectId, currentTimeSeconds);
+        return accessHistory.isCountIncreasable(projectId, currentTimeSeconds);
     }
 
-    public Cookie createOrUpdateCookie(long projectId, ProjectViewTimes projectViewTimes) {
-        if (projectViewTimes.isEmpty()) {
-            return createCookie(projectId, projectViewTimes);
+    public Cookie createOrUpdateCookie(long projectId, AccessHistory accessHistory) {
+        if (accessHistory.isEmpty()) {
+            return createCookie(projectId, accessHistory);
         }
-        return updateCookie(projectId, projectViewTimes);
+        return updateCookie(projectId, accessHistory);
     }
 
-    private Cookie createCookie(long projectId, ProjectViewTimes projectViewTimes) {
+    private Cookie createCookie(long projectId, AccessHistory accessHistory) {
         long currentTimeSeconds = getCurrentTimeSeconds();
         long secondsUntilMidnight = getSecondsUntilMidnight(currentTimeSeconds);
 
-        projectViewTimes.add(projectId, currentTimeSeconds);
-        return buildValidCookie(projectViewTimes, secondsUntilMidnight);
+        accessHistory.add(projectId, currentTimeSeconds);
+        return buildValidCookie(accessHistory, secondsUntilMidnight);
     }
 
-    private Cookie updateCookie(long projectId, ProjectViewTimes projectViewTimes) {
+    private Cookie updateCookie(long projectId, AccessHistory accessHistory) {
         long currentTimeSeconds = getCurrentTimeSeconds();
         long secondsUntilMidnight = getSecondsUntilMidnight(currentTimeSeconds);
 
-        projectViewTimes.removeExpiredEntries(currentTimeSeconds);
-        projectViewTimes.add(projectId, currentTimeSeconds);
-        projectViewTimes.removeUntilMaxSize();
-        return buildValidCookie(projectViewTimes, secondsUntilMidnight);
+        accessHistory.removeExpiredEntries(currentTimeSeconds);
+        accessHistory.add(projectId, currentTimeSeconds);
+        accessHistory.removeUntilMaxSize();
+        return buildValidCookie(accessHistory, secondsUntilMidnight);
     }
 
-    private Cookie buildValidCookie(ProjectViewTimes projectViewTimes, long secondsUntilMidnight) {
-        String json = projectViewTimes.serializeWithSizeLimit();
-        if (projectViewTimes.isInvalidForCookie(json)) {
+    private Cookie buildValidCookie(AccessHistory accessHistory, long secondsUntilMidnight) {
+        String json = accessHistory.serializeWithSizeLimit();
+        if (accessHistory.isInvalidForCookie(json)) {
             return createEmptyCookie();
         }
         return buildCookieFromJson(json, secondsUntilMidnight);
@@ -69,8 +71,8 @@ public class ProjectViewCookieManager {
 
     private Cookie buildCookieFromJson(String json, long secondsUntilMidnight) {
         String encoded = URLEncoder.encode(json, StandardCharsets.UTF_8);
-        Cookie cookie = new Cookie(COOKIE_NAME, encoded);
-        cookie.setPath(COOKIE_PATH);
+        Cookie cookie = new Cookie(cookieName, encoded);
+        cookie.setPath(cookiePath);
         cookie.setMaxAge((int) secondsUntilMidnight);
         cookie.setHttpOnly(true);
         cookie.setSecure(true);
@@ -78,8 +80,8 @@ public class ProjectViewCookieManager {
     }
 
     private Cookie createEmptyCookie() {
-        Cookie cookie = new Cookie(COOKIE_NAME, "");
-        cookie.setPath(COOKIE_PATH);
+        Cookie cookie = new Cookie(cookieName, "");
+        cookie.setPath(cookiePath);
         cookie.setMaxAge(0);
         cookie.setHttpOnly(true);
         cookie.setSecure(true);
@@ -102,7 +104,7 @@ public class ProjectViewCookieManager {
             return null;
         }
         return Arrays.stream(request.getCookies()).
-                filter(cookie -> cookie.getName().equals(COOKIE_NAME))
+                filter(cookie -> cookie.getName().equals(cookieName))
                 .findFirst()
                 .orElse(null);
     }

--- a/backend/src/main/java/moaon/backend/global/exception/custom/ErrorCode.java
+++ b/backend/src/main/java/moaon/backend/global/exception/custom/ErrorCode.java
@@ -9,9 +9,8 @@ public enum ErrorCode {
     UNKNOWN("GLOBAL-001", "예기치 못한 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     RESOURCE_NOT_FOUND("GLOBAL-002", "요청한 리소스를 찾을 수 없습니다", HttpStatus.NOT_FOUND),
     MISSING_REQUIRED_PARAMETER("GLOBAL-003", "필수 요청 파라미터가 누락되었습니다.", HttpStatus.BAD_REQUEST),
-
     PROJECT_NOT_FOUND("PROJECT-001", "프로젝트를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-
+    ARTICLE_NOT_FOUND("ARTICLE-001", "프로젝트를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     INVALID_CURSOR_FORMAT("CURSOR-001", "커서 파라미터 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST);
 
     private final String id;

--- a/backend/src/main/java/moaon/backend/project/controller/ProjectController.java
+++ b/backend/src/main/java/moaon/backend/project/controller/ProjectController.java
@@ -4,15 +4,15 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
-import moaon.backend.global.cookie.ProjectViewCookieManager;
-import moaon.backend.global.cookie.ProjectViewTimes;
 import moaon.backend.article.dto.ArticleDetailResponse;
 import moaon.backend.article.service.ArticleService;
+import moaon.backend.global.cookie.AccessHistory;
+import moaon.backend.global.cookie.TrackingCookieManager;
 import moaon.backend.project.dto.ProjectDetailResponse;
 import moaon.backend.project.dto.ProjectQueryCondition;
 import moaon.backend.project.dto.ProjectSummaryResponse;
 import moaon.backend.project.service.ProjectService;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -22,12 +22,20 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/projects")
-@RequiredArgsConstructor
 public class ProjectController {
 
-    private final ProjectViewCookieManager cookieManager;
+    private final TrackingCookieManager cookieManager;
     private final ProjectService projectService;
     private final ArticleService articleService;
+
+    public ProjectController(
+            @Qualifier("projectViewCookieManager") TrackingCookieManager cookieManager,
+            ProjectService projectService,
+            ArticleService articleService) {
+        this.cookieManager = cookieManager;
+        this.projectService = projectService;
+        this.articleService = articleService;
+    }
 
     @GetMapping("/{id}")
     public ResponseEntity<ProjectDetailResponse> getProjectById(
@@ -35,10 +43,10 @@ public class ProjectController {
             HttpServletRequest request,
             HttpServletResponse response
     ) {
-        ProjectViewTimes projectViewTimes = cookieManager.extractViewedMap(request);
-        if (cookieManager.isViewCountIncreasable(id, projectViewTimes)) {
+        AccessHistory accessHistory = cookieManager.extractViewedMap(request);
+        if (cookieManager.isCountIncreasable(id, accessHistory)) {
             ProjectDetailResponse projectDetailResponse = projectService.increaseViewsCount(id);
-            Cookie cookie = cookieManager.createOrUpdateCookie(id, projectViewTimes);
+            Cookie cookie = cookieManager.createOrUpdateCookie(id, accessHistory);
             response.addCookie(cookie);
             return ResponseEntity.ok(projectDetailResponse);
         }

--- a/backend/src/test/java/moaon/backend/fixture/RepositoryHelper.java
+++ b/backend/src/test/java/moaon/backend/fixture/RepositoryHelper.java
@@ -3,6 +3,8 @@ package moaon.backend.fixture;
 import moaon.backend.article.domain.Article;
 import moaon.backend.article.repository.ArticleCategoryRepository;
 import moaon.backend.article.repository.ArticleRepository;
+import moaon.backend.global.exception.custom.CustomException;
+import moaon.backend.global.exception.custom.ErrorCode;
 import moaon.backend.member.repository.MemberRepository;
 import moaon.backend.project.domain.Project;
 import moaon.backend.project.repository.ProjectCategoryRepository;
@@ -46,5 +48,10 @@ public class RepositoryHelper {
         save(article.getProject());
 
         return articleRepository.save(article);
+    }
+
+    public Article findById(long id) {
+        return articleRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.ARTICLE_NOT_FOUND));
     }
 }


### PR DESCRIPTION
# 🎯 이슈 번호

close #117

## ✅ 체크 리스트

- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 🏁 작업 내용

POST articles/{id}/clicks API 기능을 구현하였습니다.

조회수와 클릭수 증가 로직이 매우 유사하여, 기존 쿠키 매니저를 재사용하되 쿠키 이름과 경로만 다르게 설정하는 방식으로 처리했습니다.
이를 위해 두 가지 빈(Bean)을 주입하는 형태가 되었고, 이 과정에서 롬복의 `@RequiredArgsConstructor`를 사용할 수 없게 되었습니다.

`@Qualifier`를 활용한 생성자 주입을 명시적으로 작성하면서, 롬복의 자동 생성자를 대체하는 방법으로 구성했습니다.

만약 이보다 더 간편하거나 깔끔한 방법이 있다면 편하게 피드백 부탁드립니다.
## 🎸 기타
- 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
