### PR TITLE
feat(FE): 아티클 페이지 필터링, 정렬 기능 구현

### DIFF
--- a/frontend/src/domains/components/SortList/SortItem/SortItem.tsx
+++ b/frontend/src/domains/components/SortList/SortItem/SortItem.tsx
@@ -1,20 +1,20 @@
+import type { PropsWithChildren } from "react";
 import * as S from "./SortItem.styled";
 
 interface SortItemProps {
-  sortValue: string;
   isSelected: boolean;
   onSelect: () => void;
 }
 
-function SortItem({ sortValue, isSelected, onSelect }: SortItemProps) {
+function SortItem({
+  isSelected,
+  onSelect,
+  children,
+}: PropsWithChildren<SortItemProps>) {
   return (
     <S.Item>
-      <S.Button
-        type="button"
-        onClick={() => onSelect()}
-        isSelected={isSelected}
-      >
-        {sortValue}
+      <S.Button type="button" onClick={onSelect} isSelected={isSelected}>
+        {children}
       </S.Button>
     </S.Item>
   );

--- a/frontend/src/domains/components/SortList/SortList.tsx
+++ b/frontend/src/domains/components/SortList/SortList.tsx
@@ -1,29 +1,24 @@
 import { Separated } from "@shared/components/Separated/Separated";
 import useSearchParams from "@shared/hooks/useSearchParams";
 import { typeSafeObjectEntries } from "@shared/utils/typeSafeObjectEntries";
-import { useState } from "react";
 import SortItem from "./SortItem/SortItem";
 import * as S from "./SortList.styled";
 
 interface SortListProps {
   sortMap: Record<string, string>;
   onSelect: () => void;
+  initialValue: string;
 }
 
-function SortList({ sortMap, onSelect }: SortListProps) {
+function SortList({ sortMap, onSelect, initialValue }: SortListProps) {
   const params = useSearchParams({
     key: "sort",
     mode: "single",
   });
 
-  const sortParamValue = params.get()[0];
-  const defaultSortValue = Object.values(sortMap)[0];
-  const [selectedSort, setSelectedSort] = useState(
-    sortParamValue ?? defaultSortValue,
-  );
-
-  const handleSelectedSort = (sortKey: string, sortValue: string) => {
-    setSelectedSort(sortValue);
+  const [rawSortParams] = params.get();
+  const sortParams = rawSortParams ?? initialValue;
+  const handleSelectedSort = (sortKey: string) => {
     params.update(sortKey);
     onSelect();
   };
@@ -35,8 +30,8 @@ function SortList({ sortMap, onSelect }: SortListProps) {
           <SortItem
             key={sortValue}
             sortValue={sortValue}
-            isSelected={selectedSort === sortValue}
-            onSelect={() => handleSelectedSort(sortKey, sortValue)}
+            isSelected={sortParams === sortKey}
+            onSelect={() => handleSelectedSort(sortKey)}
           />
         ))}
       </Separated>

--- a/frontend/src/domains/components/SortList/SortList.tsx
+++ b/frontend/src/domains/components/SortList/SortList.tsx
@@ -20,7 +20,7 @@ function SortList<T extends Record<string, string>>({
     mode: "single",
   });
 
-  const [rawSortParams] = params.get();
+  const rawSortParams = params.get()[0];
   const sortParams = rawSortParams ?? initialValue;
   const handleSelectedSort = (sortKey: string) => {
     params.update(sortKey);

--- a/frontend/src/domains/components/SortList/SortList.tsx
+++ b/frontend/src/domains/components/SortList/SortList.tsx
@@ -2,15 +2,15 @@ import { Separated } from "@shared/components/Separated/Separated";
 import useSearchParams from "@shared/hooks/useSearchParams";
 import { typeSafeObjectEntries } from "@shared/utils/typeSafeObjectEntries";
 import { useState } from "react";
-import useProjectList from "../../../pages/project-list/hooks/useProjectList";
 import SortItem from "./SortItem/SortItem";
 import * as S from "./SortList.styled";
 
 interface SortListProps {
   sortMap: Record<string, string>;
+  onSelect: () => void;
 }
 
-function SortList({ sortMap }: SortListProps) {
+function SortList({ sortMap, onSelect }: SortListProps) {
   const params = useSearchParams({
     key: "sort",
     mode: "single",
@@ -22,12 +22,10 @@ function SortList({ sortMap }: SortListProps) {
     sortParamValue ?? defaultSortValue,
   );
 
-  const { refetch } = useProjectList();
-
   const handleSelectedSort = (sortKey: string, sortValue: string) => {
     setSelectedSort(sortValue);
     params.update(sortKey);
-    refetch();
+    onSelect();
   };
 
   return (

--- a/frontend/src/domains/components/SortList/SortList.tsx
+++ b/frontend/src/domains/components/SortList/SortList.tsx
@@ -4,13 +4,17 @@ import { typeSafeObjectEntries } from "@shared/utils/typeSafeObjectEntries";
 import SortItem from "./SortItem/SortItem";
 import * as S from "./SortList.styled";
 
-interface SortListProps {
-  sortMap: Record<string, string>;
+interface SortListProps<T extends Record<string, string>> {
+  sortMap: T;
   onSelect: () => void;
-  initialValue: string;
+  initialValue: keyof T;
 }
 
-function SortList({ sortMap, onSelect, initialValue }: SortListProps) {
+function SortList<T extends Record<string, string>>({
+  sortMap,
+  onSelect,
+  initialValue,
+}: SortListProps<T>) {
   const params = useSearchParams({
     key: "sort",
     mode: "single",
@@ -29,10 +33,11 @@ function SortList({ sortMap, onSelect, initialValue }: SortListProps) {
         {typeSafeObjectEntries(sortMap).map(([sortKey, sortValue]) => (
           <SortItem
             key={sortValue}
-            sortValue={sortValue}
             isSelected={sortParams === sortKey}
-            onSelect={() => handleSelectedSort(sortKey)}
-          />
+            onSelect={() => handleSelectedSort(sortKey.toString())}
+          >
+            {sortValue}
+          </SortItem>
         ))}
       </Separated>
     </S.List>

--- a/frontend/src/domains/sort/article.ts
+++ b/frontend/src/domains/sort/article.ts
@@ -1,4 +1,4 @@
 export const ARTICLE_SORT_MAP = {
   createdAt: "최신순",
-  views: "조회순",
+  clicks: "조회순",
 } as const;

--- a/frontend/src/pages/article/ArticlePage.tsx
+++ b/frontend/src/pages/article/ArticlePage.tsx
@@ -8,6 +8,9 @@ import CardList from "./CardList/CardList";
 import useArticleList from "./hooks/useArticleList";
 import TagList from "./TagList/TagList";
 
+const DEFAULT_SORT_TYPE = "createdAt";
+const DEFAULT_FILTER_TYPE = "all";
+
 function ArticlePage() {
   const { refetch, isLoading, articles } = useArticleList();
 
@@ -37,7 +40,7 @@ function ArticlePage() {
       <Tab
         items={articleCategoryItems}
         onSelect={handleSelect}
-        initialValue="all"
+        initialValue={DEFAULT_FILTER_TYPE}
       />
       <S.Box>
         <S.ArticleContainer>
@@ -49,7 +52,7 @@ function ArticlePage() {
             <SortList
               sortMap={ARTICLE_SORT_MAP}
               onSelect={handleSelect}
-              initialValue="createdAt"
+              initialValue={DEFAULT_SORT_TYPE}
             />
           </S.ArticleHeader>
           <CardList articles={articles.articleContents} />

--- a/frontend/src/pages/article/ArticlePage.tsx
+++ b/frontend/src/pages/article/ArticlePage.tsx
@@ -34,7 +34,11 @@ function ArticlePage() {
         </S.TitleBox>
         <ArticleSearchBar />
       </S.MainBox>
-      <Tab items={articleCategoryItems} onSelect={handleSelect} />
+      <Tab
+        items={articleCategoryItems}
+        onSelect={handleSelect}
+        initialValue="all"
+      />
       <S.Box>
         <S.ArticleContainer>
           <S.ArticleHeader>
@@ -42,7 +46,11 @@ function ArticlePage() {
               <S.ArticleIntroText>{articles.totalCount}개</S.ArticleIntroText>의
               아티클이 모여있어요.
             </S.ArticleIntro>
-            <SortList sortMap={ARTICLE_SORT_MAP} onSelect={handleSelect} />
+            <SortList
+              sortMap={ARTICLE_SORT_MAP}
+              onSelect={handleSelect}
+              initialValue="createdAt"
+            />
           </S.ArticleHeader>
           <CardList articles={articles.articleContents} />
         </S.ArticleContainer>

--- a/frontend/src/pages/article/ArticlePage.tsx
+++ b/frontend/src/pages/article/ArticlePage.tsx
@@ -9,7 +9,7 @@ import useArticleList from "./hooks/useArticleList";
 import TagList from "./TagList/TagList";
 
 function ArticlePage() {
-  const { isLoading, articles } = useArticleList();
+  const { refetch, isLoading, articles } = useArticleList();
 
   const articleCategoryItems = ARTICLE_CATEGORY_ENTRY.map(([key, value]) => ({
     key,
@@ -18,6 +18,10 @@ function ArticlePage() {
 
   if (isLoading) return <div>Loading...</div>;
   if (!articles) return <div>No articles found</div>;
+
+  const handleSelect = () => {
+    refetch();
+  };
 
   return (
     <S.Main>
@@ -38,7 +42,7 @@ function ArticlePage() {
               <S.ArticleIntroText>{articles.totalCount}개</S.ArticleIntroText>의
               아티클이 모여있어요.
             </S.ArticleIntro>
-            <SortList sortMap={ARTICLE_SORT_MAP} />
+            <SortList sortMap={ARTICLE_SORT_MAP} onSelect={handleSelect} />
           </S.ArticleHeader>
           <CardList articles={articles.articleContents} />
         </S.ArticleContainer>

--- a/frontend/src/pages/article/ArticlePage.tsx
+++ b/frontend/src/pages/article/ArticlePage.tsx
@@ -14,9 +14,9 @@ const DEFAULT_FILTER_TYPE = "all";
 function ArticlePage() {
   const { refetch, isLoading, articles } = useArticleList();
 
-  const articleCategoryItems = ARTICLE_CATEGORY_ENTRY.map(([key, value]) => ({
+  const articleCategories = ARTICLE_CATEGORY_ENTRY.map(([key, { label }]) => ({
     key,
-    label: value.label,
+    label,
   }));
 
   if (isLoading) return <div>Loading...</div>;
@@ -38,7 +38,7 @@ function ArticlePage() {
         <ArticleSearchBar />
       </S.MainBox>
       <Tab
-        items={articleCategoryItems}
+        items={articleCategories}
         onSelect={handleSelect}
         initialValue={DEFAULT_FILTER_TYPE}
       />
@@ -49,7 +49,7 @@ function ArticlePage() {
               <S.ArticleIntroText>{articles.totalCount}개</S.ArticleIntroText>의
               아티클이 모여있어요.
             </S.ArticleIntro>
-            <SortList
+            <SortList<typeof ARTICLE_SORT_MAP>
               sortMap={ARTICLE_SORT_MAP}
               onSelect={handleSelect}
               initialValue={DEFAULT_SORT_TYPE}

--- a/frontend/src/pages/article/ArticlePage.tsx
+++ b/frontend/src/pages/article/ArticlePage.tsx
@@ -34,7 +34,7 @@ function ArticlePage() {
         </S.TitleBox>
         <ArticleSearchBar />
       </S.MainBox>
-      <Tab items={articleCategoryItems} />
+      <Tab items={articleCategoryItems} onSelect={handleSelect} />
       <S.Box>
         <S.ArticleContainer>
           <S.ArticleHeader>

--- a/frontend/src/pages/article/ArticlePage.tsx
+++ b/frontend/src/pages/article/ArticlePage.tsx
@@ -22,6 +22,8 @@ function ArticlePage() {
   if (isLoading) return <div>Loading...</div>;
   if (!articles) return <div>No articles found</div>;
 
+  const { articleContents, totalCount } = articles;
+
   const handleSelect = () => {
     refetch();
   };
@@ -46,8 +48,8 @@ function ArticlePage() {
         <S.ArticleContainer>
           <S.ArticleHeader>
             <S.ArticleIntro>
-              <S.ArticleIntroText>{articles.totalCount}개</S.ArticleIntroText>의
-              아티클이 모여있어요.
+              <S.ArticleIntroText>{totalCount}개</S.ArticleIntroText>의 아티클이
+              모여있어요.
             </S.ArticleIntro>
             <SortList<typeof ARTICLE_SORT_MAP>
               sortMap={ARTICLE_SORT_MAP}
@@ -55,7 +57,7 @@ function ArticlePage() {
               initialValue={DEFAULT_SORT_TYPE}
             />
           </S.ArticleHeader>
-          <CardList articles={articles.articleContents} />
+          <CardList articles={articleContents} />
         </S.ArticleContainer>
         <TagList />
       </S.Box>

--- a/frontend/src/pages/article/ArticlePage.tsx
+++ b/frontend/src/pages/article/ArticlePage.tsx
@@ -1,4 +1,4 @@
-import { ARTICLE_CATEGORY_MAP } from "@domains/filter/articleCategory";
+import { ARTICLE_CATEGORY_ENTRY } from "@domains/filter/articleCategory";
 import { ARTICLE_SORT_MAP } from "@domains/sort/article";
 import Tab from "@shared/components/Tab/Tab";
 import SortList from "../../domains/components/SortList/SortList";
@@ -10,9 +10,11 @@ import TagList from "./TagList/TagList";
 
 function ArticlePage() {
   const { isLoading, articles } = useArticleList();
-  const articleCategoryLabels = Object.values(ARTICLE_CATEGORY_MAP).map(
-    (item) => item.label,
-  );
+
+  const articleCategoryItems = ARTICLE_CATEGORY_ENTRY.map(([key, value]) => ({
+    key,
+    label: value.label,
+  }));
 
   if (isLoading) return <div>Loading...</div>;
   if (!articles) return <div>No articles found</div>;
@@ -28,7 +30,7 @@ function ArticlePage() {
         </S.TitleBox>
         <ArticleSearchBar />
       </S.MainBox>
-      <Tab items={articleCategoryLabels} />
+      <Tab items={articleCategoryItems} />
       <S.Box>
         <S.ArticleContainer>
           <S.ArticleHeader>

--- a/frontend/src/pages/article/TagList/Tag/Tag.styled.ts
+++ b/frontend/src/pages/article/TagList/Tag/Tag.styled.ts
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 
-export const TagBox = styled.li`
-  background-color: #f2f4f6;
+export const TagBox = styled.li<{ isSelected: boolean }>`
+  background-color: ${({ isSelected }) => (isSelected ? "#007bff" : "#f2f4f6")};
   border-radius: 1.5rem;
   padding: 0.5rem 1rem;
   cursor: pointer;
@@ -15,6 +15,6 @@ export const TagBox = styled.li`
   }
 `;
 
-export const TagText = styled.span`
-  color: #555555;
+export const TagText = styled.span<{ isSelected: boolean }>`
+  color: ${({ isSelected }) => (isSelected ? "#ffffff" : "#555555")};
 `;

--- a/frontend/src/pages/article/TagList/Tag/Tag.tsx
+++ b/frontend/src/pages/article/TagList/Tag/Tag.tsx
@@ -1,16 +1,20 @@
+import type { PropsWithChildren } from "react";
 import * as S from "./Tag.styled";
 
 interface TagBoxProps {
-  text: string;
   onSelect: () => void;
   isSelected: boolean;
 }
 
-function Tag({ text, onSelect, isSelected }: TagBoxProps) {
+function Tag({
+  children,
+  onSelect,
+  isSelected,
+}: PropsWithChildren<TagBoxProps>) {
   return (
     <S.TagBox onClick={onSelect} isSelected={isSelected}>
       <S.TagText className="tag-text" isSelected={isSelected}>
-        {text}
+        {children}
       </S.TagText>
     </S.TagBox>
   );

--- a/frontend/src/pages/article/TagList/Tag/Tag.tsx
+++ b/frontend/src/pages/article/TagList/Tag/Tag.tsx
@@ -2,12 +2,16 @@ import * as S from "./Tag.styled";
 
 interface TagBoxProps {
   text: string;
+  onSelect: () => void;
+  isSelected: boolean;
 }
 
-function Tag({ text }: TagBoxProps) {
+function Tag({ text, onSelect, isSelected }: TagBoxProps) {
   return (
-    <S.TagBox>
-      <S.TagText className="tag-text">{text}</S.TagText>
+    <S.TagBox onClick={onSelect} isSelected={isSelected}>
+      <S.TagText className="tag-text" isSelected={isSelected}>
+        {text}
+      </S.TagText>
     </S.TagBox>
   );
 }

--- a/frontend/src/pages/article/TagList/TagList.tsx
+++ b/frontend/src/pages/article/TagList/TagList.tsx
@@ -1,4 +1,4 @@
-import { TECH_STACK_ENTRY } from "@domains/filter/techStack";
+import { TECH_STACK_ENTRY, type TechStackKey } from "@domains/filter/techStack";
 import useSearchParams from "@shared/hooks/useSearchParams";
 import useArticleList from "../hooks/useArticleList";
 import Tag from "./Tag/Tag";
@@ -9,7 +9,7 @@ function TagList() {
   const selectedTags = tagParams.get();
   const { refetch } = useArticleList();
 
-  const handleTagSelect = (value: string) => {
+  const handleTagSelect = (value: TechStackKey) => {
     tagParams.update(value);
     refetch();
   };

--- a/frontend/src/pages/article/TagList/TagList.tsx
+++ b/frontend/src/pages/article/TagList/TagList.tsx
@@ -1,17 +1,35 @@
-import { TECH_STACK_ICON_MAP } from "@domains/filter/techStack";
+import { TECH_STACK_ENTRY } from "@domains/filter/techStack";
+import useSearchParams from "@shared/hooks/useSearchParams";
+import useArticleList from "../hooks/useArticleList";
 import Tag from "./Tag/Tag";
 import * as S from "./TagList.styled";
 
 function TagList() {
-  const techStacks = Object.values(TECH_STACK_ICON_MAP);
+  const tagParams = useSearchParams({ key: "techStacks", mode: "multi" }); // TODO: 쿼리파라미터를 "tag"로 변경하는것이 유지보수에 적절함
+  const selectedTags = tagParams.get();
+  const { refetch } = useArticleList();
+
+  const handleTagSelect = (value: string) => {
+    tagParams.update(value);
+    refetch();
+  };
 
   return (
     <S.TagListContainer>
       <S.TagListTitle>태그</S.TagListTitle>
       <S.TagList>
-        {techStacks.map(({ label }) => (
-          <Tag key={label} text={label} />
-        ))}
+        {TECH_STACK_ENTRY.map(([key, { label }]) => {
+          const isSelected = selectedTags.includes(key);
+
+          return (
+            <Tag
+              onSelect={() => handleTagSelect(key)}
+              key={label}
+              text={label}
+              isSelected={isSelected}
+            />
+          );
+        })}
       </S.TagList>
     </S.TagListContainer>
   );

--- a/frontend/src/pages/article/TagList/TagList.tsx
+++ b/frontend/src/pages/article/TagList/TagList.tsx
@@ -25,9 +25,10 @@ function TagList() {
             <Tag
               onSelect={() => handleTagSelect(key)}
               key={label}
-              text={label}
               isSelected={isSelected}
-            />
+            >
+              {label}
+            </Tag>
           );
         })}
       </S.TagList>

--- a/frontend/src/pages/project-list/ProjectListPage.tsx
+++ b/frontend/src/pages/project-list/ProjectListPage.tsx
@@ -44,7 +44,7 @@ function ProjectListPage() {
             </S.ResetButton>
           )}
         </S.Wrap>
-        <SortList
+        <SortList<typeof PROJECT_SORT_MAP>
           sortMap={PROJECT_SORT_MAP}
           onSelect={handleSelect}
           initialValue={DEFAULT_SORT_TYPE}

--- a/frontend/src/pages/project-list/ProjectListPage.tsx
+++ b/frontend/src/pages/project-list/ProjectListPage.tsx
@@ -42,7 +42,11 @@ function ProjectListPage() {
             </S.ResetButton>
           )}
         </S.Wrap>
-        <SortList sortMap={PROJECT_SORT_MAP} onSelect={handleSelect} />
+        <SortList
+          sortMap={PROJECT_SORT_MAP}
+          onSelect={handleSelect}
+          initialValue="createdAt"
+        />
       </S.Box>
       <CardList />
     </S.Main>

--- a/frontend/src/pages/project-list/ProjectListPage.tsx
+++ b/frontend/src/pages/project-list/ProjectListPage.tsx
@@ -17,6 +17,10 @@ function ProjectListPage() {
     refetch();
   };
 
+  const handleSelect = () => {
+    refetch();
+  };
+
   const isSelected = techStacks.length > 0 || categories.length > 0;
   return (
     <S.Main>
@@ -38,7 +42,7 @@ function ProjectListPage() {
             </S.ResetButton>
           )}
         </S.Wrap>
-        <SortList sortMap={PROJECT_SORT_MAP} />
+        <SortList sortMap={PROJECT_SORT_MAP} onSelect={handleSelect} />
       </S.Box>
       <CardList />
     </S.Main>

--- a/frontend/src/pages/project-list/ProjectListPage.tsx
+++ b/frontend/src/pages/project-list/ProjectListPage.tsx
@@ -8,6 +8,8 @@ import useProjectList from "./hooks/useProjectList";
 import * as S from "./ProjectListPage.styled";
 import ProjectSearchBar from "./ProjectSearchBar/ProjectSearchBar";
 
+const DEFAULT_SORT_TYPE = "createdAt";
+
 function ProjectListPage() {
   const { techStacks, categories, resetFilter } = useFilterParams();
   const { refetch } = useProjectList();
@@ -45,7 +47,7 @@ function ProjectListPage() {
         <SortList
           sortMap={PROJECT_SORT_MAP}
           onSelect={handleSelect}
-          initialValue="createdAt"
+          initialValue={DEFAULT_SORT_TYPE}
         />
       </S.Box>
       <CardList />

--- a/frontend/src/shared/components/Tab/Tab.tsx
+++ b/frontend/src/shared/components/Tab/Tab.tsx
@@ -9,14 +9,16 @@ interface TabItem {
 interface TabProps {
   items: TabItem[];
   onSelect: () => void;
+  initialValue: string;
 }
 
-function Tab({ items, onSelect }: TabProps) {
+function Tab({ items, onSelect, initialValue }: TabProps) {
   const categoryParams = useSearchParams({
     key: "category",
     mode: "single",
   });
-  const [selectedCategory] = categoryParams.get();
+  const [rawSelectedCategory] = categoryParams.get();
+  const selectedCategory = rawSelectedCategory ?? initialValue;
 
   const handleTabItemClick = (value: string) => {
     categoryParams.update(value);

--- a/frontend/src/shared/components/Tab/Tab.tsx
+++ b/frontend/src/shared/components/Tab/Tab.tsx
@@ -1,3 +1,4 @@
+import type { ArticleCategoryKey } from "@domains/filter/articleCategory";
 import useSearchParams from "@shared/hooks/useSearchParams";
 import * as S from "./Tab.styled";
 
@@ -9,7 +10,7 @@ interface TabItem {
 interface TabProps {
   items: TabItem[];
   onSelect: () => void;
-  initialValue: string;
+  initialValue: ArticleCategoryKey;
 }
 
 function Tab({ items, onSelect, initialValue }: TabProps) {

--- a/frontend/src/shared/components/Tab/Tab.tsx
+++ b/frontend/src/shared/components/Tab/Tab.tsx
@@ -1,6 +1,4 @@
 import useSearchParams from "@shared/hooks/useSearchParams";
-import { useEffect, useState } from "react";
-import useArticleList from "../../../pages/article/hooks/useArticleList";
 import * as S from "./Tab.styled";
 
 interface TabItem {
@@ -10,40 +8,31 @@ interface TabItem {
 
 interface TabProps {
   items: TabItem[];
+  onSelect: () => void;
 }
 
-function Tab({ items }: TabProps) {
+function Tab({ items, onSelect }: TabProps) {
   const categoryParams = useSearchParams({
     key: "category",
     mode: "single",
   });
-  const { refetch } = useArticleList();
   const [selectedCategory] = categoryParams.get();
-  const selectedIndex = selectedCategory
-    ? items.findIndex((item) => item.key === selectedCategory)
-    : 0;
-  const [currentIndex, setCurrentIndex] = useState(selectedIndex);
 
-  useEffect(() => {
-    setCurrentIndex(selectedIndex);
-  }, [selectedIndex]);
-
-  const handleTabItemClick = (value: string, index: number) => {
-    setCurrentIndex(index);
+  const handleTabItemClick = (value: string) => {
     categoryParams.update(value);
-    refetch();
+    onSelect();
   };
 
   return (
     <S.TabContainer>
       <S.TabItemList>
-        {items.map(({ key, label }, index) => {
-          const isSelected = currentIndex === index;
+        {items.map(({ key, label }) => {
+          const isSelected = selectedCategory === key;
           return (
             <S.TabItem
               key={key}
               isSelected={isSelected}
-              onClick={() => handleTabItemClick(key, index)}
+              onClick={() => handleTabItemClick(key)}
             >
               {label}
             </S.TabItem>

--- a/frontend/src/shared/components/Tab/Tab.tsx
+++ b/frontend/src/shared/components/Tab/Tab.tsx
@@ -1,25 +1,51 @@
-import { useState } from "react";
+import useSearchParams from "@shared/hooks/useSearchParams";
+import { useEffect, useState } from "react";
+import useArticleList from "../../../pages/article/hooks/useArticleList";
 import * as S from "./Tab.styled";
 
+interface TabItem {
+  key: string;
+  label: string;
+}
+
 interface TabProps {
-  items: string[];
+  items: TabItem[];
 }
 
 function Tab({ items }: TabProps) {
-  const [selectedIndex, setSelectedIndex] = useState(0);
+  const categoryParams = useSearchParams({
+    key: "category",
+    mode: "single",
+  });
+  const { refetch } = useArticleList();
+  const [selectedCategory] = categoryParams.get();
+  const selectedIndex = selectedCategory
+    ? items.findIndex((item) => item.key === selectedCategory)
+    : 0;
+  const [currentIndex, setCurrentIndex] = useState(selectedIndex);
+
+  useEffect(() => {
+    setCurrentIndex(selectedIndex);
+  }, [selectedIndex]);
+
+  const handleTabItemClick = (value: string, index: number) => {
+    setCurrentIndex(index);
+    categoryParams.update(value);
+    refetch();
+  };
 
   return (
     <S.TabContainer>
       <S.TabItemList>
-        {items.map((item, index) => {
-          const isSelected = selectedIndex === index;
+        {items.map(({ key, label }, index) => {
+          const isSelected = currentIndex === index;
           return (
             <S.TabItem
-              key={item}
+              key={key}
               isSelected={isSelected}
-              onClick={() => setSelectedIndex(index)}
+              onClick={() => handleTabItemClick(key, index)}
             >
-              {item}
+              {label}
             </S.TabItem>
           );
         })}


### PR DESCRIPTION
# 🎯 이슈 번호

close #155 

## ✅ 체크 리스트

- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 🏁 작업 내용

- 아티클 페이지의 탭 컴포넌트 카테고리 정렬과 조회순, 최신순 정렬, 태그 필터링 기능을 구현하였습니다.

## 🎸 기타

- SortList의 initialValue이 string 타입으로 지정되어있습니다. 
아래의 객체의 key값을 모아둔 것을 유니온 타입으로 받는게 가장 좋은 방법일까요?

```ts
export const ARTICLE_SORT_MAP = {
  createdAt: "최신순",
  clicks: "조회순",
} as const;
```

```ts
export const PROJECT_SORT_MAP = {
  createdAt: "최신순",
  views: "조회순",
  loves: "좋아요순",
} as const;
```