### PR TITLE
style(FE): 카드 제목 및 내용의 스타일 개선

### DIFF
--- a/frontend/src/pages/article/CardList/Card/Card.styled.ts
+++ b/frontend/src/pages/article/CardList/Card/Card.styled.ts
@@ -26,12 +26,13 @@ export const CardTitle = styled.h2`
   font-size: 1.125rem;
   font-weight: 700;
   line-height: 1.25;
+  height: 2.8125rem;
   ${textOverflowEllipsis(2)}
 `;
 
 export const CardSummary = styled.span`
   font-size: 0.8125rem;
-  line-height: 1.25;
+  line-height: 1.5;
   color: #555555;
   ${textOverflowEllipsis(3)}
 `;


### PR DESCRIPTION
# 🎯 이슈 번호

close #181 

## ✅ 체크 리스트

- [ ] Target Branch를 올바르게 설정했나요?
- [ ] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 🏁 작업 내용

- 아티클 페이지의 카드 제목에 높이를 지정해 일정한 영역을 차지하도록 개선
- 아티클 페이지의 요약에 행간을 1.25에서 1.5로 상향
