### PR TITLE
feat(FE): 탭 컴포넌트 도메인 종속 제거

### DIFF
--- a/frontend/src/domains/components/SortList/SortList.tsx
+++ b/frontend/src/domains/components/SortList/SortList.tsx
@@ -23,7 +23,7 @@ function SortList<T extends Record<string, string>>({
   const rawSortParams = params.get()[0];
   const sortParams = rawSortParams ?? initialValue;
   const handleSelectedSort = (sortKey: string) => {
-    params.update(sortKey);
+    params.update(sortKey, { replace: true });
     onSelect();
   };
 

--- a/frontend/src/domains/filter/techStack.ts
+++ b/frontend/src/domains/filter/techStack.ts
@@ -62,9 +62,9 @@ export const TECH_STACK_ICON_MAP = {
       "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Express.svg",
   },
   nestjs: {
-    label: "NestJS",
+    label: "Nest.js",
     imgUrl:
-      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Next.js.svg",
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Nest.js.svg",
   },
   django: {
     label: "Django",
@@ -275,6 +275,41 @@ export const TECH_STACK_ICON_MAP = {
     label: "SwiftUI",
     imgUrl:
       "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/SwiftUI.svg",
+  },
+  githubAction: {
+    label: "Github Action",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/GithubAction.svg",
+  },
+  git: {
+    label: "Git",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Git.svg",
+  },
+  elasticsearch: {
+    label: "ElasticSearch",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/ElasticSearch.svg",
+  },
+  grafana: {
+    label: "Grafana",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Grafana.svg",
+  },
+  jenkins: {
+    label: "Jenkins",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Jenkins.svg",
+  },
+  jpa: {
+    label: "JPA",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/JPA.svg",
+  },
+  querydsl: {
+    label: "Querydsl",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Querydsl.svg",
   },
 } as const;
 

--- a/frontend/src/pages/article/ArticlePage.tsx
+++ b/frontend/src/pages/article/ArticlePage.tsx
@@ -13,12 +13,13 @@ import useArticleList from "./hooks/useArticleList";
 import TagList from "./TagList/TagList";
 
 const DEFAULT_SORT_TYPE = "createdAt";
-const DEFAULT_FILTER_TYPE = "all";
+const DEFAULT_ARTICLE_CATEGORY_TYPE = "all";
 
 function ArticlePage() {
   const { refetch, isLoading, articles } = useArticleList();
-  const { selectedCategory, updateCategory } =
-    useArticleCategory(DEFAULT_FILTER_TYPE);
+  const { selectedCategory, updateCategory } = useArticleCategory(
+    DEFAULT_ARTICLE_CATEGORY_TYPE,
+  );
 
   const articleCategories = ARTICLE_CATEGORY_ENTRY.map(([key, { label }]) => ({
     key,

--- a/frontend/src/pages/article/ArticlePage.tsx
+++ b/frontend/src/pages/article/ArticlePage.tsx
@@ -1,6 +1,10 @@
-import { ARTICLE_CATEGORY_ENTRY } from "@domains/filter/articleCategory";
+import {
+  ARTICLE_CATEGORY_ENTRY,
+  type ArticleCategoryKey,
+} from "@domains/filter/articleCategory";
 import { ARTICLE_SORT_MAP } from "@domains/sort/article";
 import Tab from "@shared/components/Tab/Tab";
+import useSearchParams from "@shared/hooks/useSearchParams";
 import SortList from "../../domains/components/SortList/SortList";
 import ArticleSearchBar from "./ArticleSearchBar/ArticleSearchBar";
 import * as S from "./AticlePage.styled";
@@ -14,6 +18,15 @@ const DEFAULT_FILTER_TYPE = "all";
 function ArticlePage() {
   const { refetch, isLoading, articles } = useArticleList();
 
+  const categoryParams = useSearchParams({
+    key: "category",
+    mode: "single",
+  });
+
+  const rawSelectedCategory = categoryParams.get()[0];
+  const selectedCategory = (rawSelectedCategory ??
+    DEFAULT_FILTER_TYPE) as ArticleCategoryKey;
+
   const articleCategories = ARTICLE_CATEGORY_ENTRY.map(([key, { label }]) => ({
     key,
     label,
@@ -25,6 +38,11 @@ function ArticlePage() {
   const { articleContents, totalCount } = articles;
 
   const handleSelect = () => {
+    refetch();
+  };
+
+  const handleTabSelect = (key: ArticleCategoryKey) => {
+    categoryParams.update(key);
     refetch();
   };
 
@@ -41,8 +59,8 @@ function ArticlePage() {
       </S.MainBox>
       <Tab
         items={articleCategories}
-        onSelect={handleSelect}
-        initialValue={DEFAULT_FILTER_TYPE}
+        onSelect={handleTabSelect}
+        selected={selectedCategory}
       />
       <S.Box>
         <S.ArticleContainer>

--- a/frontend/src/pages/article/ArticlePage.tsx
+++ b/frontend/src/pages/article/ArticlePage.tsx
@@ -4,11 +4,11 @@ import {
 } from "@domains/filter/articleCategory";
 import { ARTICLE_SORT_MAP } from "@domains/sort/article";
 import Tab from "@shared/components/Tab/Tab";
-import useSearchParams from "@shared/hooks/useSearchParams";
 import SortList from "../../domains/components/SortList/SortList";
 import ArticleSearchBar from "./ArticleSearchBar/ArticleSearchBar";
 import * as S from "./AticlePage.styled";
 import CardList from "./CardList/CardList";
+import { useArticleCategory } from "./hooks/useArticleCategory";
 import useArticleList from "./hooks/useArticleList";
 import TagList from "./TagList/TagList";
 
@@ -17,15 +17,8 @@ const DEFAULT_FILTER_TYPE = "all";
 
 function ArticlePage() {
   const { refetch, isLoading, articles } = useArticleList();
-
-  const categoryParams = useSearchParams({
-    key: "category",
-    mode: "single",
-  });
-
-  const rawSelectedCategory = categoryParams.get()[0];
-  const selectedCategory = (rawSelectedCategory ??
-    DEFAULT_FILTER_TYPE) as ArticleCategoryKey;
+  const { selectedCategory, updateCategory } =
+    useArticleCategory(DEFAULT_FILTER_TYPE);
 
   const articleCategories = ARTICLE_CATEGORY_ENTRY.map(([key, { label }]) => ({
     key,
@@ -42,7 +35,7 @@ function ArticlePage() {
   };
 
   const handleTabSelect = (key: ArticleCategoryKey) => {
-    categoryParams.update(key);
+    updateCategory(key);
     refetch();
   };
 

--- a/frontend/src/pages/article/ArticleSearchBar/ArticleSearchBar.tsx
+++ b/frontend/src/pages/article/ArticleSearchBar/ArticleSearchBar.tsx
@@ -8,12 +8,12 @@ function ArticleSearchBar() {
 
   const handleSearchSubmit = (value: string) => {
     if (value === "") {
-      params.deleteAll();
+      params.deleteAll({ replace: true });
       refetch();
       return;
     }
 
-    params.update(value);
+    params.update(value, { replace: true });
     refetch();
   };
 

--- a/frontend/src/pages/article/CardList/Card/Card.styled.ts
+++ b/frontend/src/pages/article/CardList/Card/Card.styled.ts
@@ -26,12 +26,13 @@ export const CardTitle = styled.h2`
   font-size: 1.125rem;
   font-weight: 700;
   line-height: 1.25;
+  height: 2.8125rem;
   ${textOverflowEllipsis(2)}
 `;
 
 export const CardSummary = styled.span`
   font-size: 0.8125rem;
-  line-height: 1.25;
+  line-height: 1.5;
   color: #555555;
   ${textOverflowEllipsis(3)}
 `;

--- a/frontend/src/pages/article/CardList/Card/Card.styled.ts
+++ b/frontend/src/pages/article/CardList/Card/Card.styled.ts
@@ -33,6 +33,7 @@ export const CardTitle = styled.h2`
 export const CardSummary = styled.span`
   font-size: 0.8125rem;
   line-height: 1.5;
+  height: 3.66rem;
   color: #555555;
   ${textOverflowEllipsis(3)}
 `;

--- a/frontend/src/pages/article/TagList/TagList.tsx
+++ b/frontend/src/pages/article/TagList/TagList.tsx
@@ -10,7 +10,7 @@ function TagList() {
   const { refetch } = useArticleList();
 
   const handleTagSelect = (value: TechStackKey) => {
-    tagParams.update(value);
+    tagParams.update(value, { replace: true });
     refetch();
   };
 

--- a/frontend/src/pages/article/hooks/useArticleCategory.ts
+++ b/frontend/src/pages/article/hooks/useArticleCategory.ts
@@ -7,9 +7,8 @@ export const useArticleCategory = (defaultValue: ArticleCategoryKey) => {
     mode: "single",
   });
 
-  const rawSelectedCategory = categoryParams.get()[0];
-  const selectedCategory = (rawSelectedCategory ??
-    defaultValue) as ArticleCategoryKey;
+  const rawSelectedCategory = categoryParams.get()[0] as ArticleCategoryKey;
+  const selectedCategory = rawSelectedCategory ?? defaultValue;
 
   const updateCategory = (key: ArticleCategoryKey) => {
     categoryParams.update(key);

--- a/frontend/src/pages/article/hooks/useArticleCategory.ts
+++ b/frontend/src/pages/article/hooks/useArticleCategory.ts
@@ -11,7 +11,7 @@ export const useArticleCategory = (defaultValue: ArticleCategoryKey) => {
   const selectedCategory = rawSelectedCategory ?? defaultValue;
 
   const updateCategory = (key: ArticleCategoryKey) => {
-    categoryParams.update(key);
+    categoryParams.update(key, { replace: true });
   };
 
   return { selectedCategory, updateCategory };

--- a/frontend/src/pages/article/hooks/useArticleCategory.ts
+++ b/frontend/src/pages/article/hooks/useArticleCategory.ts
@@ -1,0 +1,19 @@
+import type { ArticleCategoryKey } from "@domains/filter/articleCategory";
+import useSearchParams from "@shared/hooks/useSearchParams";
+
+export const useArticleCategory = (defaultValue: ArticleCategoryKey) => {
+  const categoryParams = useSearchParams({
+    key: "category",
+    mode: "single",
+  });
+
+  const rawSelectedCategory = categoryParams.get()[0];
+  const selectedCategory = (rawSelectedCategory ??
+    defaultValue) as ArticleCategoryKey;
+
+  const updateCategory = (key: ArticleCategoryKey) => {
+    categoryParams.update(key);
+  };
+
+  return { selectedCategory, updateCategory };
+};

--- a/frontend/src/pages/project-list/FilterContainer/FilterTrigger/CategoryFilterBox/CategoryFilterList/CategoryFilterButton/CategoryFilterButton.tsx
+++ b/frontend/src/pages/project-list/FilterContainer/FilterTrigger/CategoryFilterBox/CategoryFilterList/CategoryFilterButton/CategoryFilterButton.tsx
@@ -33,7 +33,7 @@ function CategoryFilterButton({ value, label }: CategoryFilterButtonProps) {
 
   const handleFilterButtonClick = (value: string) => {
     toggle();
-    params.update(value);
+    params.update(value, { replace: true });
     refetch();
   };
 

--- a/frontend/src/pages/project-list/FilterContainer/FilterTrigger/FilterBox/FilterBox.tsx
+++ b/frontend/src/pages/project-list/FilterContainer/FilterTrigger/FilterBox/FilterBox.tsx
@@ -13,7 +13,7 @@ function FilterBox({ children, param }: PropsWithChildren<FilterBoxProps>) {
   const { refetch } = useProjectList();
 
   const handelFilterResetButtonClick = () => {
-    params.deleteAll();
+    params.deleteAll({ replace: true });
     refetch();
   };
 

--- a/frontend/src/pages/project-list/ProjectSearchBar/ProjectSearchBar.tsx
+++ b/frontend/src/pages/project-list/ProjectSearchBar/ProjectSearchBar.tsx
@@ -8,12 +8,12 @@ function ProjectSearchBar() {
 
   const handleSearchSubmit = (value: string) => {
     if (value === "") {
-      params.deleteAll();
+      params.deleteAll({ replace: true });
       refetch();
       return;
     }
 
-    params.update(value);
+    params.update(value, { replace: true });
     refetch();
   };
 

--- a/frontend/src/pages/project-list/hooks/useFilterParams.ts
+++ b/frontend/src/pages/project-list/hooks/useFilterParams.ts
@@ -16,11 +16,11 @@ export const useFilterParams = () => {
   };
 
   const updateTechStackParam = (techStack: string) => {
-    techStackParams.update(techStack);
+    techStackParams.update(techStack, { replace: true });
   };
 
   const updateCategoryParam = (category: string) => {
-    categoryParams.update(category);
+    categoryParams.update(category, { replace: true });
   };
 
   return {

--- a/frontend/src/shared/components/Tab/Tab.tsx
+++ b/frontend/src/shared/components/Tab/Tab.tsx
@@ -1,17 +1,17 @@
 import * as S from "./Tab.styled";
 
-interface TabItem<T extends string> {
-  key: T;
+interface TabItem<K extends string> {
+  key: K;
   label: string;
 }
 
-interface TabProps<T extends string> {
-  items: TabItem<T>[];
-  onSelect: (key: T) => void;
-  selected: T;
+interface TabProps<K extends string> {
+  items: TabItem<K>[];
+  onSelect: (key: K) => void;
+  selected: K;
 }
 
-function Tab<T extends string>({ items, selected, onSelect }: TabProps<T>) {
+function Tab<K extends string>({ items, selected, onSelect }: TabProps<K>) {
   return (
     <S.TabContainer>
       <S.TabItemList>

--- a/frontend/src/shared/components/Tab/Tab.tsx
+++ b/frontend/src/shared/components/Tab/Tab.tsx
@@ -22,7 +22,7 @@ function Tab({ items, onSelect, initialValue }: TabProps) {
   const selectedCategory = rawSelectedCategory ?? initialValue;
 
   const handleTabItemClick = (value: string) => {
-    categoryParams.update(value);
+    categoryParams.update(value, { replace: true });
     onSelect();
   };
 

--- a/frontend/src/shared/components/Tab/Tab.tsx
+++ b/frontend/src/shared/components/Tab/Tab.tsx
@@ -1,41 +1,27 @@
-import type { ArticleCategoryKey } from "@domains/filter/articleCategory";
-import useSearchParams from "@shared/hooks/useSearchParams";
 import * as S from "./Tab.styled";
 
-interface TabItem {
-  key: string;
+interface TabItem<T extends string> {
+  key: T;
   label: string;
 }
 
-interface TabProps {
-  items: TabItem[];
-  onSelect: () => void;
-  initialValue: ArticleCategoryKey;
+interface TabProps<T extends string> {
+  items: TabItem<T>[];
+  onSelect: (key: T) => void;
+  selected: T;
 }
 
-function Tab({ items, onSelect, initialValue }: TabProps) {
-  const categoryParams = useSearchParams({
-    key: "category",
-    mode: "single",
-  });
-  const [rawSelectedCategory] = categoryParams.get();
-  const selectedCategory = rawSelectedCategory ?? initialValue;
-
-  const handleTabItemClick = (value: string) => {
-    categoryParams.update(value, { replace: true });
-    onSelect();
-  };
-
+function Tab<T extends string>({ items, selected, onSelect }: TabProps<T>) {
   return (
     <S.TabContainer>
       <S.TabItemList>
         {items.map(({ key, label }) => {
-          const isSelected = selectedCategory === key;
+          const isSelected = selected === key;
           return (
             <S.TabItem
               key={key}
               isSelected={isSelected}
-              onClick={() => handleTabItemClick(key)}
+              onClick={() => onSelect(key)}
             >
               {label}
             </S.TabItem>

--- a/frontend/src/shared/hooks/useSearchParams.ts
+++ b/frontend/src/shared/hooks/useSearchParams.ts
@@ -1,5 +1,8 @@
 import { useCallback } from "react";
-import { useSearchParams as useReactRouterSearchParams } from "react-router";
+import {
+  type NavigateOptions,
+  useSearchParams as useReactRouterSearchParams,
+} from "react-router";
 
 type SearchParamOptions = {
   key: string;
@@ -20,26 +23,29 @@ const useSearchParams = ({ key, mode }: SearchParamOptions) => {
   }, [key, searchParams]);
 
   const updateSearchParams = useCallback(
-    (values: string[]) => {
+    (values: string[], options?: NavigateOptions) => {
       const params = new URLSearchParams(searchParams);
       params.delete(key);
 
       if (values.length === 0) {
-        setSearchParams(params);
+        setSearchParams(params, options);
         return;
       }
 
       params.append(key, values.join(","));
-      setSearchParams(params);
+      setSearchParams(params, options);
     },
     [key, searchParams, setSearchParams]
   );
 
-  const deleteAllSearchParams = useCallback(() => {
-    const params = new URLSearchParams(searchParams);
-    params.delete(key);
-    setSearchParams(params);
-  }, [key, searchParams, setSearchParams]);
+  const deleteAllSearchParams = useCallback(
+    (options?: NavigateOptions) => {
+      const params = new URLSearchParams(searchParams);
+      params.delete(key);
+      setSearchParams(params, options);
+    },
+    [key, searchParams, setSearchParams]
+  );
 
   const paramOperations = {
     single: (value: string) => [value],
@@ -51,9 +57,9 @@ const useSearchParams = ({ key, mode }: SearchParamOptions) => {
     },
   };
 
-  const updateParamValue = (value: string) => {
+  const updateParamValue = (value: string, options?: { replace?: boolean }) => {
     const newValues = paramOperations[mode](value);
-    updateSearchParams(newValues);
+    updateSearchParams(newValues, options);
   };
 
   return {


### PR DESCRIPTION
# 🎯 이슈 번호

close #183 

## ✅ 체크 리스트

- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 🏁 작업 내용

- shared 폴더의 탭 컴포넌트의 도메인 종속을 제거하였습니다.
- 탭 컴포넌트를 사용하면 Article 페이지에서 useArticleCategory 훅을 불러서 선택된 카테고리 상태를 관리하도록 하였습니다.
