### PR TITLE
feat(FE): Sentry 오류 보고 기능 추가 및 에러 처리 개선

### DIFF
--- a/frontend/src/libs/sentry/errorReporter.ts
+++ b/frontend/src/libs/sentry/errorReporter.ts
@@ -1,0 +1,85 @@
+import type { Context } from "@sentry/react";
+import * as Sentry from "@sentry/react";
+import type { Component } from "react";
+import type { ErrorInfo } from "react-dom/client";
+import { typeSafeError } from "./utils/typeSafeError";
+
+interface QueryLike {
+  queryKey: readonly unknown[];
+}
+
+interface MutationLike {
+  options: {
+    mutationKey?: readonly unknown[];
+  };
+}
+
+interface ErrorInfoWithErrorBoundary extends ErrorInfo {
+  errorBoundary?: Component<unknown>;
+}
+
+export const sentryRenderError = (error: unknown, errorInfo: ErrorInfoWithErrorBoundary, errorType: string) => {
+  const errorObj = typeSafeError(error);
+
+  Sentry.captureException(errorObj, {
+    tags: { errorType },
+    contexts: {
+      react: errorInfo as Context,
+    },
+  });
+};
+
+export const sentryRenderRecoverable = (error: unknown, errorInfo: ErrorInfo) => {
+  const errorObj = typeSafeError(error);
+
+  Sentry.captureException(errorObj, {
+    tags: { errorType: "react-recoverable-error" },
+    level: "warning",
+    contexts: {
+      react: {
+        componentStack: errorInfo?.componentStack || "No component stack",
+        errorBoundary: true,
+        recoverable: true,
+      },
+    },
+  });
+};
+
+export const sentryQueryError = (error: Error, query: QueryLike) => {
+  Sentry.captureException(error, {
+    tags: {
+      errorType: "api-query",
+    },
+    contexts: {
+      api: {
+        type: "query",
+        queryKey: query.queryKey,
+        message: error.message || "Unknown error",
+        name: error.name || "Error",
+        url: (error as any)?.url || "unknown",
+        status: (error as any)?.status || "unknown",
+      },
+    },
+  });
+};
+
+export const sentryMutationError = (error: Error, variables: unknown, mutation: MutationLike) => {
+  Sentry.captureException(error, {
+    tags: {
+      errorType: "api-mutation",
+    },
+    contexts: {
+      api: {
+        type: "mutation",
+        mutationKey: mutation.options.mutationKey,
+        message: error.message || "Unknown error",
+        name: error.name || "Error",
+        url: (error as any)?.url || "unknown",
+        status: (error as any)?.status || "unknown",
+      },
+    },
+    extra: {
+      variables,
+    },
+  });
+};

--- a/frontend/src/libs/sentry/initializeSentry.ts
+++ b/frontend/src/libs/sentry/initializeSentry.ts
@@ -3,13 +3,7 @@ import * as Sentry from "@sentry/react";
 Sentry.init({
   dsn: process.env.SENTRY_API_DNS,
   sendDefaultPii: true,
-  integrations: [
-    Sentry.browserTracingIntegration(),
-    Sentry.replayIntegration(),
-    Sentry.feedbackIntegration({
-      colorScheme: "system",
-    }),
-  ],
+  integrations: [Sentry.browserTracingIntegration(), Sentry.replayIntegration()],
   enableLogs: true,
   tracesSampleRate: 1.0,
   replaysSessionSampleRate: 0.1,

--- a/frontend/src/libs/sentry/utils/typeSafeError.ts
+++ b/frontend/src/libs/sentry/utils/typeSafeError.ts
@@ -1,0 +1,6 @@
+export const typeSafeError = (error: unknown): Error => {
+  if (error instanceof Error) {
+    return error;
+  }
+  return new Error(String(error));
+};


### PR DESCRIPTION
# 🎯 이슈 번호

close #164 

## ✅ 체크 리스트

- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 🏁 작업 내용

- React Query 에러 발생 시 Sentry로 자동 전송되도록 설정 추가
  - Query 에러 (데이터 조회 실패한 경우)
  - Mutation 에러 (데이터 변경 실패한 경우)
- main.tsx 가독성 향상을 위해 Sentry 에러 리포팅 로직을 `libs/sentry/errorReporter.ts`로 분리
- sentry에 error boundary 설정
- sentry user feedback 기능 제거
