### PR TITLE
refactor: unmount 애니메이션 적용 컴포넌트(`UnmountAfterAnimation`) 개선

### DIFF
--- a/frontend/src/pages/project-list/FilterContainer/FilterTrigger/FilterTrigger.tsx
+++ b/frontend/src/pages/project-list/FilterContainer/FilterTrigger/FilterTrigger.tsx
@@ -1,5 +1,5 @@
 import { SwitchCase } from "@shared/components/SwitchCase/SwitchCase";
-import UnmountAnimation from "@shared/components/UnmountAnimation/UnmountAnimation";
+import UnmountAfterAnimation from "@shared/components/UnmountAnimation/UnmountAnimation";
 import { useOutsideClick } from "@shared/hooks/useOutsideClick";
 import useSearchParams from "@shared/hooks/useSearchParams";
 import { useState } from "react";
@@ -38,7 +38,7 @@ function FilterTrigger({ label, param, onSelect }: FilterProps) {
         <ArrowIcon direction={isOpen ? "up" : "down"} />
       </S.FilterButton>
 
-      <UnmountAnimation visible={isOpen}>
+      <UnmountAfterAnimation visible={isOpen}>
         <FilterBox param={param} onSelect={onSelect} isOpen={isOpen}>
           <SwitchCase
             value={label}
@@ -48,7 +48,7 @@ function FilterTrigger({ label, param, onSelect }: FilterProps) {
             }}
           />
         </FilterBox>
-      </UnmountAnimation>
+      </UnmountAfterAnimation>
     </S.Container>
   );
 }


### PR DESCRIPTION
# 🎯 이슈 번호

close #349 

## ✅ 체크 리스트

- [X] Target Branch를 올바르게 설정했나요?
- [X] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 🏁 작업 내용

- `getAnimations`, `finished` Web API 사용하는 방식으로 개선

## 🎸 기타

**기존 방식의 문제점:**
- 자식 요소(children)에 애니메이션이 없는 경우 `animationend` 이벤트가 동작하지 않아 unmount 되지 않는 문제가 발생할 수 있습니다.
- 또한 자식 요소에 여러 개의 애니메이션이 있다면, 가장 먼저 종료된 애니메이션에 이벤트가 트리거 되어 unmount 할 수 있어 나머지 애니메이션이 끝나지 않는 상태에서도 unmount가 진행되는 문제가 있었습니다.

**개선 방식:**
- 콜백 ref를 활용해서 최상위 컨테이너 요소에 접근하고 `getAnimations({ subtree: true })` 메서드를 통해 자식 요소의 모든 애니메이션을 가져옵니다.
- `animation` 객체의 `finished` 속성을 통해 애니메이션이 끝나는 시점을 알 수 있는 Promise를 반환하고 `Promise.all`를 활용하여 모든 애니메이션이 끝난 후에 unmount 시키는 방식입니다.

[React에서 unmount 애니메이션 적용하기](https://velog.io/@woogur29/React%EC%97%90%EC%84%9C-unmount-%EC%95%A0%EB%8B%88%EB%A9%94%EC%9D%B4%EC%85%98-%EC%A0%81%EC%9A%A9%ED%95%98%EA%B8%B0)
