### PR TITLE
chore: CD 속도 개선

### DIFF
--- a/.github/workflows/be-ci.yml
+++ b/.github/workflows/be-ci.yml
@@ -12,7 +12,7 @@ jobs:
       github.actor == 'Minuring' ||
       github.actor == 'eueo8259' ||
       github.actor == 'minjae8563'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     defaults:
       run:

--- a/.github/workflows/be-dev-cd.yml
+++ b/.github/workflows/be-dev-cd.yml
@@ -29,6 +29,24 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Gradle cache for Docker
+        id: gradle_cache
+        uses: actions/cache@v4
+        with:
+          path: ./gradle-cache-home
+          key: ${{ runner.os }}-gradle-cache-${{ hashFiles('build.gradle', 'settings.gradle', 'gradle/wrapper/**') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-cache-
+
+      - name: Restore Gradle cache mounts to BuildKit
+        uses: reproducible-containers/buildkit-cache-dance@v3
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-dir: ./gradle-cache-home
+          dockerfile: ./backend/Dockerfile
+          skip-extraction: ${{ steps.gradle_cache.outputs.cache-hit }}
+
+
       - name: Build and push Docker image
         id: build
         uses: docker/build-push-action@v5

--- a/.github/workflows/be-dev-cd.yml
+++ b/.github/workflows/be-dev-cd.yml
@@ -3,8 +3,6 @@ name: BE Dev CD
 on:
   push:
     branches: [ "develop" ]
-  pull_request:
-    branches: [ "develop" ]
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/be-dev-cd.yml
+++ b/.github/workflows/be-dev-cd.yml
@@ -33,16 +33,16 @@ jobs:
         id: gradle_cache
         uses: actions/cache@v4
         with:
-          path: ./gradle-cache-home
-          key: ${{ runner.os }}-gradle-cache-${{ hashFiles('build.gradle', 'settings.gradle', 'gradle/wrapper/**') }}
+          path: ./gradle-cache-dev-home
+          key: ${{ runner.os }}-gradle-cache-dev-${{ hashFiles('build.gradle', 'settings.gradle', 'gradle/wrapper/**') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-cache-
+            ${{ runner.os }}-gradle-cache-dev-
 
       - name: Restore Gradle cache mounts to BuildKit
         uses: reproducible-containers/buildkit-cache-dance@v3
         with:
           builder: ${{ steps.buildx.outputs.name }}
-          cache-dir: ./gradle-cache-home
+          cache-dir: ./gradle-cache-dev-home
           dockerfile: ./backend/Dockerfile
           skip-extraction: ${{ steps.gradle_cache.outputs.cache-hit }}
 

--- a/.github/workflows/be-dev-cd.yml
+++ b/.github/workflows/be-dev-cd.yml
@@ -44,7 +44,7 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           cache-dir: ./gradle-cache-dev-home
           dockerfile: ./backend/Dockerfile
-          skip-extraction: ${{ steps.gradle_cache.outputs.cache-hit }}
+#          skip-extraction: ${{ steps.gradle_cache.outputs.cache-hit }}
 
 
       - name: Build and push Docker image

--- a/.github/workflows/be-dev-cd.yml
+++ b/.github/workflows/be-dev-cd.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
@@ -45,7 +46,6 @@ jobs:
           cache-dir: ./gradle-cache-dev-home
           dockerfile: ./backend/Dockerfile
           skip-extraction: ${{ steps.gradle_cache.outputs.cache-hit }}
-
 
       - name: Build and push Docker image
         id: build

--- a/.github/workflows/be-dev-cd.yml
+++ b/.github/workflows/be-dev-cd.yml
@@ -45,7 +45,7 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           cache-dir: ./gradle-cache-dev-home
           dockerfile: ./backend/Dockerfile
-          skip-extraction: false #${{ steps.gradle_cache.outputs.cache-hit }}
+          skip-extraction: ${{ steps.gradle_cache.outputs.cache-hit }}
 
       - name: Build and push Docker image
         id: build

--- a/.github/workflows/be-dev-cd.yml
+++ b/.github/workflows/be-dev-cd.yml
@@ -44,7 +44,7 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           cache-dir: ./gradle-cache-dev-home
           dockerfile: ./backend/Dockerfile
-#          skip-extraction: ${{ steps.gradle_cache.outputs.cache-hit }}
+          skip-extraction: ${{ steps.gradle_cache.outputs.cache-hit }}
 
 
       - name: Build and push Docker image

--- a/.github/workflows/be-dev-cd.yml
+++ b/.github/workflows/be-dev-cd.yml
@@ -18,9 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/be-dev-cd.yml
+++ b/.github/workflows/be-dev-cd.yml
@@ -11,7 +11,7 @@ jobs:
       github.actor == 'Minuring' ||
       github.actor == 'eueo8259' ||
       github.actor == 'minjae8563'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     defaults:
       run:
         working-directory: ./backend

--- a/.github/workflows/be-dev-cd.yml
+++ b/.github/workflows/be-dev-cd.yml
@@ -45,7 +45,7 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           cache-dir: ./gradle-cache-dev-home
           dockerfile: ./backend/Dockerfile
-          skip-extraction: ${{ steps.gradle_cache.outputs.cache-hit }}
+          skip-extraction: false #${{ steps.gradle_cache.outputs.cache-hit }}
 
       - name: Build and push Docker image
         id: build

--- a/.github/workflows/be-dev-cd.yml
+++ b/.github/workflows/be-dev-cd.yml
@@ -3,6 +3,8 @@ name: BE Dev CD
 on:
   push:
     branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/be-prod-cd.yml
+++ b/.github/workflows/be-prod-cd.yml
@@ -14,9 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/be-prod-cd.yml
+++ b/.github/workflows/be-prod-cd.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub

--- a/.github/workflows/be-prod-cd.yml
+++ b/.github/workflows/be-prod-cd.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-and-push-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     defaults:
       run:
         working-directory: ./backend

--- a/.github/workflows/be-prod-cd.yml
+++ b/.github/workflows/be-prod-cd.yml
@@ -27,16 +27,16 @@ jobs:
         id: gradle_cache
         uses: actions/cache@v4
         with:
-          path: ./gradle-cache-home
-          key: ${{ runner.os }}-gradle-cache-${{ hashFiles('build.gradle', 'settings.gradle', 'gradle/wrapper/**') }}
+          path: ./gradle-cache-prod-home
+          key: ${{ runner.os }}-gradle-cache-prod-${{ hashFiles('build.gradle', 'settings.gradle', 'gradle/wrapper/**') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-cache-
+            ${{ runner.os }}-gradle-cache-prod-
 
       - name: Restore Gradle cache mounts to BuildKit
         uses: reproducible-containers/buildkit-cache-dance@v3
         with:
           builder: ${{ steps.buildx.outputs.name }}
-          cache-dir: ./gradle-cache-home
+          cache-dir: ./gradle-cache-prod-home
           dockerfile: ./backend/Dockerfile
           skip-extraction: ${{ steps.gradle_cache.outputs.cache-hit }}
 

--- a/.github/workflows/be-prod-cd.yml
+++ b/.github/workflows/be-prod-cd.yml
@@ -23,6 +23,23 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Gradle cache for Docker
+        id: gradle_cache
+        uses: actions/cache@v4
+        with:
+          path: ./gradle-cache-home
+          key: ${{ runner.os }}-gradle-cache-${{ hashFiles('build.gradle', 'settings.gradle', 'gradle/wrapper/**') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-cache-
+
+      - name: Restore Gradle cache mounts to BuildKit
+        uses: reproducible-containers/buildkit-cache-dance@v3
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-dir: ./gradle-cache-home
+          dockerfile: ./backend/Dockerfile
+          skip-extraction: ${{ steps.gradle_cache.outputs.cache-hit }}
+
       - name: Build and push Docker image
         id: build
         uses: docker/build-push-action@v5

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,11 +7,15 @@ COPY gradle ./gradle
 COPY build.gradle .
 COPY settings.gradle .
 
-RUN chmod +x ./gradlew && ./gradlew dependencies --no-daemon
+RUN chmod +x ./gradlew
+
+RUN --mount=type=cache,target=/root/.gradle,id=gradle-home,sharing=locked \
+    ./gradlew --no-daemon dependencies
 
 COPY src ./src
 
-RUN ./gradlew bootJar --no-daemon
+RUN --mount=type=cache,target=/root/.gradle,id=gradle-home,sharing=locked \
+    ./gradlew --no-daemon bootJar
 
 FROM amazoncorretto:21-alpine
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -112,4 +112,4 @@ bootJar {
 tasks.named('build') {
     dependsOn asciidoctor
 }
-// test
+// test2

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -112,3 +112,4 @@ bootJar {
 tasks.named('build') {
     dependsOn asciidoctor
 }
+// test

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -112,4 +112,3 @@ bootJar {
 tasks.named('build') {
     dependsOn asciidoctor
 }
-

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -112,3 +112,4 @@ bootJar {
 tasks.named('build') {
     dependsOn asciidoctor
 }
+

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -112,3 +112,4 @@ bootJar {
 tasks.named('build') {
     dependsOn asciidoctor
 }
+// init cache

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -112,4 +112,3 @@ bootJar {
 tasks.named('build') {
     dependsOn asciidoctor
 }
-// init cache

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -112,4 +112,3 @@ bootJar {
 tasks.named('build') {
     dependsOn asciidoctor
 }
-// test2

--- a/backend/src/main/java/moaon/backend/BackendApplication.java
+++ b/backend/src/main/java/moaon/backend/BackendApplication.java
@@ -11,5 +11,4 @@ public class BackendApplication {
     public static void main(String[] args) {
         SpringApplication.run(BackendApplication.class, args);
     }
-
 }

--- a/backend/src/main/java/moaon/backend/BackendApplication.java
+++ b/backend/src/main/java/moaon/backend/BackendApplication.java
@@ -12,5 +12,4 @@ public class BackendApplication {
         SpringApplication.run(BackendApplication.class, args);
     }
 
-    // init cache
 }

--- a/backend/src/main/java/moaon/backend/BackendApplication.java
+++ b/backend/src/main/java/moaon/backend/BackendApplication.java
@@ -12,4 +12,5 @@ public class BackendApplication {
         SpringApplication.run(BackendApplication.class, args);
     }
 
+    // init cache
 }

--- a/backend/src/main/java/moaon/backend/BackendApplication.java
+++ b/backend/src/main/java/moaon/backend/BackendApplication.java
@@ -11,5 +11,5 @@ public class BackendApplication {
     public static void main(String[] args) {
         SpringApplication.run(BackendApplication.class, args);
     }
-    // test
+    // test2
 }

--- a/backend/src/main/java/moaon/backend/BackendApplication.java
+++ b/backend/src/main/java/moaon/backend/BackendApplication.java
@@ -11,5 +11,5 @@ public class BackendApplication {
     public static void main(String[] args) {
         SpringApplication.run(BackendApplication.class, args);
     }
-
+    // test
 }

--- a/backend/src/main/java/moaon/backend/BackendApplication.java
+++ b/backend/src/main/java/moaon/backend/BackendApplication.java
@@ -11,5 +11,4 @@ public class BackendApplication {
     public static void main(String[] args) {
         SpringApplication.run(BackendApplication.class, args);
     }
-    // test2
 }

--- a/backend/src/main/java/moaon/backend/BackendApplication.java
+++ b/backend/src/main/java/moaon/backend/BackendApplication.java
@@ -11,4 +11,5 @@ public class BackendApplication {
     public static void main(String[] args) {
         SpringApplication.run(BackendApplication.class, args);
     }
+
 }


### PR DESCRIPTION
# 🎯 이슈 번호

close #337 

## ✅ 체크 리스트

- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 🏁 작업 내용

- 작업한 내용을 간략하게 작성해주세요.

1. runner의 플랫폼을 arm64로 변경
2. Dockerfile에서 캐시 마운트 적용
3. gradle 빌드 캐시 보존

1번 : 평균 10분 단축
2번, 3번 : 평균 30초 단축

[문서](https://www.notion.so/CD-25d4b52230648020a05bf64f86aa9908?source=copy_link)에 자세히  정리했습니다.

## 🎸 기타

- 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.

CI 워크플로우에서 Github Actions의 캐시 히트는 일어나는데, Gradle 빌드에서는 캐시 미스가 발생하고 있습니다. 즉 빌드 캐시를 눈 앞에 두고 히트를 못 하고 있습니다.

```bash
> Task :bootJar Excluding [com.google.protobuf:protobuf-java] Caching disabled for task ':bootJar'
  because: Build cache is disabled Not worth caching Task ':bootJar' is not up-to-date

  because: Input property 'classpath' file /Users/minu/projects/intellij-workspace/2025-moaon-test/backend/build/resources/main/static/docs/index.html has changed.

...
```
RestDocs가 매 빌드마다 변경하는 Date, Content-Length와 같은 값들 때문인데, 추후에 개선해보도록 하죠!