### PR TITLE
refactor(FE): 기술스택 분리

### DIFF
--- a/frontend/src/domains/filter/techStack.ts
+++ b/frontend/src/domains/filter/techStack.ts
@@ -176,11 +176,6 @@ export const FRONTEND_STACK_ICON_MAP = {
     imgUrl:
       "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Webpack.svg",
   },
-  githubAction: {
-    label: "Github Action",
-    imgUrl:
-      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/GithubAction.svg",
-  },
   git: {
     label: "Git",
     imgUrl:
@@ -253,11 +248,6 @@ export const BACKEND_STACK_ICON_MAP = {
     label: "Ruby on Rails",
     imgUrl:
       "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/RubyonRails.svg",
-  },
-  aws: {
-    label: "AWS",
-    imgUrl:
-      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/AWS.svg",
   },
   mongodb: {
     label: "MongoDB",
@@ -509,11 +499,6 @@ export const BACKEND_STACK_ICON_MAP = {
     imgUrl:
       "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Lombok.svg",
   },
-  githubAction: {
-    label: "Github Action",
-    imgUrl:
-      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/GithubAction.svg",
-  },
   git: {
     label: "Git",
     imgUrl:
@@ -642,11 +627,6 @@ export const ANDROID_STACK_ICON_MAP = {
     imgUrl:
       "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Okhttp3.svg",
   },
-  githubAction: {
-    label: "Github Action",
-    imgUrl:
-      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/GithubAction.svg",
-  },
   git: {
     label: "Git",
     imgUrl:
@@ -725,11 +705,6 @@ export const IOS_STACK_ICON_MAP = {
     imgUrl:
       "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/RestClient.svg",
   },
-  githubAction: {
-    label: "Github Action",
-    imgUrl:
-      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/GithubAction.svg",
-  },
   git: {
     label: "Git",
     imgUrl:
@@ -742,11 +717,25 @@ export const IOS_STACK_ICON_MAP = {
   },
 } as const;
 
+export const INFRA_STACK_ICON_MAP = {
+  aws: {
+    label: "AWS",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/AWS.svg",
+  },
+  githubAction: {
+    label: "Github Action",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/GithubAction.svg",
+  },
+} as const;
+
 export const TECH_STACK_ICON_MAP = {
   ...FRONTEND_STACK_ICON_MAP,
   ...BACKEND_STACK_ICON_MAP,
   ...ANDROID_STACK_ICON_MAP,
   ...IOS_STACK_ICON_MAP,
+  ...INFRA_STACK_ICON_MAP,
 } as const;
 
 export const TECH_STACK_GROUPS = {
@@ -754,18 +743,21 @@ export const TECH_STACK_GROUPS = {
   BE: BACKEND_STACK_ICON_MAP,
   Android: ANDROID_STACK_ICON_MAP,
   iOS: IOS_STACK_ICON_MAP,
+  Infra: INFRA_STACK_ICON_MAP,
 } as const;
 
 export type FrontendStackKey = keyof typeof FRONTEND_STACK_ICON_MAP;
 export type BackendStackKey = keyof typeof BACKEND_STACK_ICON_MAP;
 export type AndroidStackKey = keyof typeof ANDROID_STACK_ICON_MAP;
 export type IosStackKey = keyof typeof IOS_STACK_ICON_MAP;
+export type InfraStackKey = keyof typeof INFRA_STACK_ICON_MAP;
 
 export type TechStackKey =
   | FrontendStackKey
   | BackendStackKey
   | AndroidStackKey
-  | IosStackKey;
+  | IosStackKey
+  | InfraStackKey;
 
 export const FRONTEND_STACK_ENTRY = typeSafeObjectEntries(
   FRONTEND_STACK_ICON_MAP

--- a/frontend/src/domains/filter/techStack.ts
+++ b/frontend/src/domains/filter/techStack.ts
@@ -3,596 +3,742 @@ import { typeSafeObjectEntries } from "@shared/utils/typeSafeObjectEntries";
 export const FRONTEND_STACK_ICON_MAP = {
   react: {
     label: "React",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/React.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/React.svg",
   },
   nextjs: {
     label: "Next.js",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Next.js.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Next.js.svg",
   },
   vuejs: {
     label: "Vue.js",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Vue.js.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Vue.js.svg",
   },
   angular: {
     label: "Angular",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Angular.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Angular.svg",
   },
   svelte: {
     label: "Svelte",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Svelte.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Svelte.svg",
   },
   typescript: {
     label: "TypeScript",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/TypeScript.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/TypeScript.svg",
   },
   javascript: {
     label: "JavaScript",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/JavaScript.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/JavaScript.svg",
   },
   tailwind: {
     label: "TailwindCSS",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/TailwindCSS.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/TailwindCSS.svg",
   },
   redux: {
     label: "Redux",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Redux.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Redux.svg",
   },
   vite: {
     label: "Vite",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Vite.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Vite.svg",
   },
   tanstackQuery: {
     label: "Tanstack Query",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Tanstack-Query.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Tanstack-Query.svg",
   },
   jotai: {
     label: "Jotai",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Jotai.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Jotai.svg",
   },
   zustand: {
     label: "Zustand",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Zustand.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Zustand.svg",
   },
   styledComponents: {
     label: "Styled Components",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Styled-Components.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Styled-Components.svg",
   },
   emotion: {
     label: "Emotion",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Emotion.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Emotion.svg",
   },
   recoil: {
     label: "Recoil",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Recoil.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Recoil.svg",
   },
   nuxtjs: {
     label: "Nuxt.js",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Nuxt.js.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Nuxt.js.svg",
   },
   astro: {
     label: "Astro",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Astro.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Astro.svg",
   },
   solidjs: {
     label: "SolidJS",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/SolidJS.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/SolidJS.svg",
   },
   remix: {
     label: "Remix",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Remix.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Remix.svg",
   },
   biome: {
     label: "Biome",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Biome.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Biome.svg",
   },
   msw: {
     label: "MSW",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/MSW.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/MSW.svg",
   },
   jest: {
     label: "Jest",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Jest.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Jest.svg",
   },
   reacttestinglibrary: {
     label: "RTL",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/ReactTestingLibrary.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/ReactTestingLibrary.svg",
   },
   storybook: {
     label: "Storybook",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Storybook.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Storybook.svg",
   },
   babel: {
     label: "Babel",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Babel.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Babel.svg",
   },
   cypress: {
     label: "Cypress",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Cypress.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Cypress.svg",
   },
   pwa: {
     label: "PWA",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/PWA.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/PWA.svg",
   },
   sass: {
     label: "Sass",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Sass.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Sass.svg",
   },
   axios: {
     label: "Axios",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Axios.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Axios.svg",
   },
   yarnberry: {
     label: "YarnBerry",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/YarnBerry.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/YarnBerry.svg",
   },
   prettier: {
     label: "Prettier",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Prettier.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Prettier.svg",
   },
   websocket: {
     label: "Websocket",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Websocket.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Websocket.svg",
   },
   cloudfront: {
     label: "CloudFront",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/CloudFront.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/CloudFront.svg",
   },
   webpack: {
     label: "Webpack",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Webpack.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Webpack.svg",
   },
   githubAction: {
     label: "Github Action",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/GithubAction.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/GithubAction.svg",
   },
   git: {
     label: "Git",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Git.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Git.svg",
   },
   css: {
     label: "CSS",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/CSS.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/CSS.svg",
   },
   lighthouse: {
     label: "light house",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/LightHouse.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/LightHouse.svg",
   },
   reactRouter: {
     label: "react-router",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/ReactRouter.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/ReactRouter.svg",
   },
   sentry: {
     label: "Sentry",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Sentry.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Sentry.svg",
   },
   googleAnalytics: {
     label: "Google Analytics",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/GoogleAnalytics.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/GoogleAnalytics.svg",
   },
 } as const;
 
 export const BACKEND_STACK_ICON_MAP = {
   nodejs: {
     label: "Node.js",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Node.js.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Node.js.svg",
   },
   express: {
     label: "Express.js",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Express.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Express.svg",
   },
   nestjs: {
     label: "Nest.js",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Nest.js.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Nest.js.svg",
   },
   django: {
     label: "Django",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Django.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Django.svg",
   },
   fastapi: {
     label: "FastAPI",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/FastAPI.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/FastAPI.svg",
   },
   spring: {
     label: "Spring",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Spring.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Spring.svg",
   },
   springboot: {
     label: "SpringBoot",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/SpringBoot.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/SpringBoot.svg",
   },
   rubyonrails: {
     label: "Ruby on Rails",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/RubyonRails.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/RubyonRails.svg",
   },
   aws: {
     label: "AWS",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/AWS.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/AWS.svg",
   },
   mongodb: {
     label: "MongoDB",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/MongoDB.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/MongoDB.svg",
   },
   postgresql: {
     label: "PostgreSQL",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/PostgresSQL.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/PostgresSQL.svg",
   },
   mysql: {
     label: "MySQL",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/MySQL.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/MySQL.svg",
   },
   redis: {
     label: "Redis",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Redis.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Redis.svg",
   },
   kafka: {
     label: "Apache Kafka",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/ApacheKafka.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/ApacheKafka.svg",
   },
   docker: {
     label: "Docker",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Docker.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Docker.svg",
   },
   kubernetes: {
     label: "Kubernetes",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Kubernetes.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Kubernetes.svg",
   },
   java: {
     label: "Java",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Java.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Java.svg",
   },
   python: {
     label: "Python",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Python.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Python.svg",
   },
   go: {
     label: "Go",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Go.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Go.svg",
   },
   rust: {
     label: "Rust",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Rust.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Rust.svg",
   },
   deno: {
     label: "Deno",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Deno.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Deno.svg",
   },
   supabase: {
     label: "Supabase",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Supabase.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Supabase.svg",
   },
   prisma: {
     label: "Prisma",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Prisma.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Prisma.svg",
   },
   trpc: {
     label: "tRPC",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/tRPC.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/tRPC.svg",
   },
   grafana: {
     label: "Grafana",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Grafana.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Grafana.svg",
   },
   jenkins: {
     label: "Jenkins",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Jenkins.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Jenkins.svg",
   },
   jpa: {
     label: "JPA",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/JPA.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/JPA.svg",
   },
   querydsl: {
     label: "Querydsl",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Querydsl.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Querydsl.svg",
   },
   oauth2: {
     label: "OAuth2",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/OAuth2.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/OAuth2.svg",
   },
   apachezookeeper: {
     label: "Apache Zookeeper",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/ApacheZookeeper.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/ApacheZookeeper.svg",
   },
   restdocs: {
     label: "Restdocs",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Restdocs.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Restdocs.svg",
   },
   junit5: {
     label: "Junit5",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Junit5.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Junit5.svg",
   },
   restassured: {
     label: "RestAssured",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/RestAssured.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/RestAssured.svg",
   },
   mockito: {
     label: "Mockito",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Mockito.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Mockito.svg",
   },
   slf4j: {
     label: "Slf4j",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Slf4j.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Slf4j.svg",
   },
   swagger: {
     label: "Swagger",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Swagger.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Swagger.svg",
   },
   logstash: {
     label: "Logstash",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Logstash.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Logstash.svg",
   },
   kibana: {
     label: "Kibana",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Kibana.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Kibana.svg",
   },
   flyway: {
     label: "Flyway",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Flyway.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Flyway.svg",
   },
   h2: {
     label: "H2",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/H2.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/H2.svg",
   },
   nginx: {
     label: "Nginx",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Nginx.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Nginx.svg",
   },
   prometheus: {
     label: "Prometheus",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Prometheus.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Prometheus.svg",
   },
   ec2: {
     label: "EC2",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/EC2.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/EC2.svg",
   },
   s3: {
     label: "S3",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/S3.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/S3.svg",
   },
   cloudwatch: {
     label: "CloudWatch",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/CloudWatch.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/CloudWatch.svg",
   },
   jacoco: {
     label: "Jacoco",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Jacoco.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Jacoco.svg",
   },
   sonarqube: {
     label: "SonarQube",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/SonarQube.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/SonarQube.svg",
   },
   gradle: {
     label: "Gradle",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Gradle.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Gradle.svg",
   },
   jwt: {
     label: "JWT",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/JWT.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/JWT.svg",
   },
   ical4j: {
     label: "Ical4j",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Ical4j.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Ical4j.svg",
   },
   jmeter: {
     label: "Jmeter",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Jmeter.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Jmeter.svg",
   },
   jackson: {
     label: "Jackson",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Jackson.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Jackson.svg",
   },
   mariadb: {
     label: "MariaDB",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/MariaDB.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/MariaDB.svg",
   },
   sonarcloud: {
     label: "SonarCloud",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/SonarCloud.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/SonarCloud.svg",
   },
   gatling: {
     label: "Gatling",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Gatling.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Gatling.svg",
   },
   ngrinder: {
     label: "Ngrinder",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Ngrinder.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Ngrinder.svg",
   },
   rabbitmq: {
     label: "Rabbitmq",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Rabbitmq.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Rabbitmq.svg",
   },
   k6: {
     label: "K6",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/K6.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/K6.svg",
   },
   lombok: {
     label: "Lombok",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Lombok.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Lombok.svg",
   },
   githubAction: {
     label: "Github Action",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/GithubAction.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/GithubAction.svg",
   },
   git: {
     label: "Git",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Git.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Git.svg",
   },
   elasticSearch: {
     label: "ElasticSearch",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/ElasticSearch.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/ElasticSearch.svg",
   },
   springWebFlux: {
     label: "Spring WebFlux",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/SpringWebFlux.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/SpringWebFlux.svg",
   },
   log4j2: {
     label: "log4j2",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Log4j2.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Log4j2.svg",
   },
   locust: {
     label: "Locust",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Locust.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Locust.svg",
   },
   springSecurity: {
     label: "Spring Security",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/SpringSecurity.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/SpringSecurity.svg",
   },
 } as const;
 
 export const ANDROID_STACK_ICON_MAP = {
   kotlin: {
     label: "Kotlin",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Kotlin.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Kotlin.svg",
   },
   compose: {
     label: "Jetpack Compose",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/JetpackCompose.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/JetpackCompose.svg",
   },
   java: {
     label: "Java",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Java.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Java.svg",
   },
   flutter: {
     label: "Flutter",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Flutter.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Flutter.svg",
   },
   retrofit: {
     label: "Retrofit",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Retrofit.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Retrofit.svg",
   },
   moshi: {
     label: "Moshi",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Moshi.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Moshi.svg",
   },
   coroutines: {
     label: "Coroutines",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Coroutines.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Coroutines.svg",
   },
   flow: {
     label: "Flow",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Flow.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Flow.svg",
   },
   room: {
     label: "Room",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Room.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Room.svg",
   },
   dataStore: {
     label: "DataStore",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/DataStore.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/DataStore.svg",
   },
   hilt: {
     label: "Hilt",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Hilt.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Hilt.svg",
   },
   jetpack: {
     label: "Jetpack",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Jetpack.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Jetpack.svg",
   },
   firebase: {
     label: "Firebase",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Firebase.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Firebase.svg",
   },
   retrofit2: {
     label: "Retrofit2",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Retrofit2.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Retrofit2.svg",
   },
   glide: {
     label: "Glide",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Glide.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Glide.svg",
   },
   mockk: {
     label: "MockK",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Mockk.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Mockk.svg",
   },
   turbine: {
     label: "Turbine",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Turbine.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Turbine.svg",
   },
   zxing: {
     label: "Zxing",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Zxing.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Zxing.svg",
   },
   okhttp3: {
     label: "Okhttp3",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Okhttp3.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Okhttp3.svg",
   },
   githubAction: {
     label: "Github Action",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/GithubAction.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/GithubAction.svg",
   },
   git: {
     label: "Git",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Git.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Git.svg",
   },
   fusedLocationProviderClient: {
     label: "FusedLocationProviderClient",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Jetpack.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Jetpack.svg",
   },
   locationManager: {
     label: "locationManager",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Jetpack.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Jetpack.svg",
   },
   serialization: {
     label: "Serialization",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Kotlin.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Kotlin.svg",
   },
   reactNative: {
     label: "React Native",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/ReactNative.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/ReactNative.svg",
   },
   recyclerView: {
     label: "RecyclerView",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Jetpack.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Jetpack.svg",
   },
   coil: {
     label: "Coil",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Coil.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Coil.svg",
   },
   timber: {
     label: "Timber",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Timber.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Timber.svg",
   },
   lottie: {
     label: "Lottie",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Lottie.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Lottie.svg",
   },
 } as const;
 
 export const IOS_STACK_ICON_MAP = {
   swift: {
     label: "Swift",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Swift.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Swift.svg",
   },
   swiftui: {
     label: "SwiftUI",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/SwiftUI.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/SwiftUI.svg",
   },
   rxswift: {
     label: "RxSwift",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/RxSwift.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/RxSwift.svg",
   },
   alamofire: {
     label: "Alamofire",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Alamofire.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Alamofire.svg",
   },
   flutter: {
     label: "Flutter",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Flutter.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Flutter.svg",
   },
   restClient: {
     label: "Restclient",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/RestClient.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/RestClient.svg",
   },
   githubAction: {
     label: "Github Action",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/GithubAction.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/GithubAction.svg",
   },
   git: {
     label: "Git",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Git.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/Git.svg",
   },
   reactNative: {
     label: "React Native",
-    imgUrl: "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/ReactNative.svg",
+    imgUrl:
+      "https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/moaon/teckstack-icons/ReactNative.svg",
   },
 } as const;
 
@@ -603,19 +749,40 @@ export const TECH_STACK_ICON_MAP = {
   ...IOS_STACK_ICON_MAP,
 } as const;
 
+export const TECH_STACK_GROUPS = {
+  FE: FRONTEND_STACK_ICON_MAP,
+  BE: BACKEND_STACK_ICON_MAP,
+  Android: ANDROID_STACK_ICON_MAP,
+  iOS: IOS_STACK_ICON_MAP,
+} as const;
+
 export type FrontendStackKey = keyof typeof FRONTEND_STACK_ICON_MAP;
 export type BackendStackKey = keyof typeof BACKEND_STACK_ICON_MAP;
 export type AndroidStackKey = keyof typeof ANDROID_STACK_ICON_MAP;
 export type IosStackKey = keyof typeof IOS_STACK_ICON_MAP;
 
-export type TechStackKey = FrontendStackKey | BackendStackKey | AndroidStackKey | IosStackKey;
+export type TechStackKey =
+  | FrontendStackKey
+  | BackendStackKey
+  | AndroidStackKey
+  | IosStackKey;
 
-export const FRONTEND_STACK_ENTRY = typeSafeObjectEntries(FRONTEND_STACK_ICON_MAP).sort(([a], [b]) => a.localeCompare(b));
+export const FRONTEND_STACK_ENTRY = typeSafeObjectEntries(
+  FRONTEND_STACK_ICON_MAP
+).sort(([a], [b]) => a.localeCompare(b));
 
-export const BACKEND_STACK_ENTRY = typeSafeObjectEntries(BACKEND_STACK_ICON_MAP).sort(([a], [b]) => a.localeCompare(b));
+export const BACKEND_STACK_ENTRY = typeSafeObjectEntries(
+  BACKEND_STACK_ICON_MAP
+).sort(([a], [b]) => a.localeCompare(b));
 
-export const ANDROID_STACK_ENTRY = typeSafeObjectEntries(ANDROID_STACK_ICON_MAP).sort(([a], [b]) => a.localeCompare(b));
+export const ANDROID_STACK_ENTRY = typeSafeObjectEntries(
+  ANDROID_STACK_ICON_MAP
+).sort(([a], [b]) => a.localeCompare(b));
 
-export const IOS_STACK_ENTRY = typeSafeObjectEntries(IOS_STACK_ICON_MAP).sort(([a], [b]) => a.localeCompare(b));
+export const IOS_STACK_ENTRY = typeSafeObjectEntries(IOS_STACK_ICON_MAP).sort(
+  ([a], [b]) => a.localeCompare(b)
+);
 
-export const TECH_STACK_ENTRY = typeSafeObjectEntries(TECH_STACK_ICON_MAP).sort(([a], [b]) => a.localeCompare(b));
+export const TECH_STACK_ENTRY = typeSafeObjectEntries(TECH_STACK_ICON_MAP).sort(
+  ([a], [b]) => a.localeCompare(b)
+);

--- a/frontend/src/pages/project-detail/ProjectDetailPage.tsx
+++ b/frontend/src/pages/project-detail/ProjectDetailPage.tsx
@@ -26,11 +26,11 @@ function ProjectDetailPage() {
   return (
     <div>
       <TitleSection projectDetail={projectDetail} />
-      <TechStacksSection techStacks={projectDetail.techStacks} />
       {projectDetail.imageUrls.length > 0 && (
         <Carousel imageUrls={projectDetail.imageUrls} />
       )}
       <OverviewSection overview={projectDetail.description} />
+      <TechStacksSection techStacks={projectDetail.techStacks} />
       <ArticleSection
         articles={projectArticles}
         refetch={refetch}

--- a/frontend/src/pages/project-detail/components/TechStacksSection/TechStacksSection.styled.ts
+++ b/frontend/src/pages/project-detail/components/TechStacksSection/TechStacksSection.styled.ts
@@ -3,3 +3,11 @@ import styled from "@emotion/styled";
 export const TechStacksSection = styled.section`
   margin: 1.5rem 0 3rem;
 `;
+
+export const GroupName = styled.h3`
+  font-size: 1.2rem;
+  font-weight: 400;
+  margin: 1.2rem 0;
+`;
+
+export const GroupStacksWrapper = styled.div``;

--- a/frontend/src/pages/project-detail/components/TechStacksSection/TechStacksSection.tsx
+++ b/frontend/src/pages/project-detail/components/TechStacksSection/TechStacksSection.tsx
@@ -1,6 +1,7 @@
 import type { TechStackKey } from "@domains/filter/techStack";
 import { TECH_STACK_GROUPS } from "@domains/filter/techStack";
 import IconBadgeList from "@shared/components/IconBadgeList/IconBadgeList";
+import { typeSafeObjectEntries } from "@shared/utils/typeSafeObjectEntries";
 import SectionTitle from "../SectionTitle";
 import * as S from "./TechStacksSection.styled";
 
@@ -13,7 +14,7 @@ function TechStacksSection({ techStacks }: TechStacksSectionProps) {
     <S.TechStacksSection>
       <SectionTitle title="기술 스택" />
 
-      {Object.entries(TECH_STACK_GROUPS).map(([groupName, stackMap]) => {
+      {typeSafeObjectEntries(TECH_STACK_GROUPS).map(([groupName, stackMap]) => {
         const groupStacks = techStacks.filter((stack) =>
           Object.keys(stackMap).includes(stack),
         );

--- a/frontend/src/pages/project-detail/components/TechStacksSection/TechStacksSection.tsx
+++ b/frontend/src/pages/project-detail/components/TechStacksSection/TechStacksSection.tsx
@@ -1,4 +1,5 @@
 import type { TechStackKey } from "@domains/filter/techStack";
+import { TECH_STACK_GROUPS } from "@domains/filter/techStack";
 import IconBadgeList from "@shared/components/IconBadgeList/IconBadgeList";
 import SectionTitle from "../SectionTitle";
 import * as S from "./TechStacksSection.styled";
@@ -11,7 +12,21 @@ function TechStacksSection({ techStacks }: TechStacksSectionProps) {
   return (
     <S.TechStacksSection>
       <SectionTitle title="기술 스택" />
-      <IconBadgeList iconBadges={techStacks} />
+
+      {Object.entries(TECH_STACK_GROUPS).map(([groupName, stackMap]) => {
+        const groupStacks = techStacks.filter((stack) =>
+          Object.keys(stackMap).includes(stack),
+        );
+
+        if (groupStacks.length === 0) return null;
+
+        return (
+          <S.GroupStacksWrapper key={groupName}>
+            <S.GroupName>{groupName}</S.GroupName>
+            <IconBadgeList iconBadges={groupStacks} />
+          </S.GroupStacksWrapper>
+        );
+      })}
     </S.TechStacksSection>
   );
 }

--- a/frontend/src/shared/components/MoveTop/MoveTop.styled.ts
+++ b/frontend/src/shared/components/MoveTop/MoveTop.styled.ts
@@ -37,7 +37,7 @@ export const MoveTopButton = styled.button<MoveTopButtonProps>`
 
   &:hover {
     animation: ${bounceAnimation} 1.2s ease-in-out infinite;
-    background-color: #f9f9f9;
+    background-color: #0057b5ff;
   }
 `;
 


### PR DESCRIPTION
# 🎯 이슈 번호

close #372 

## ✅ 체크 리스트

- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 🏁 작업 내용
기술스택을 분야별로 분류해서 가독성을 높였습니다.

<img width="973" height="466" alt="image" src="https://github.com/user-attachments/assets/9baaa25e-d967-41eb-84c9-8d6d8e22defb" />

## 🎸 기타

현재 기술스택에 git이 공통적으로 포함되어있어, git이라는 기술스택이 존재하기만 하면 FE, BE, Android, iOS 모두에 포함되고있습니다.

모아온 프로젝트에는 iOS, Android 기술스택이 들어가면 안되는데도 불구하고, Java와 git이 있어서 iOS, Android 분류가 생기는 상황입니다. 어떻게 해결하는것이 좋을까요?

(추가적으로, 상단 이동 버튼 호버 시 색상을 변경하였습니다.)
