### PR TITLE
refactor: URLSearchParams 초기화 방식 변경 및 불필요한 파라미터 삭제

### DIFF
--- a/frontend/src/pages/article/hooks/useUpdateSectorParams.ts
+++ b/frontend/src/pages/article/hooks/useUpdateSectorParams.ts
@@ -5,11 +5,14 @@ export const useUpdateSectorParams = () => {
   const navigate = useNavigate();
 
   return (newSector: string) => {
-    const params = new URLSearchParams(location.search);
-
+    const params = new URLSearchParams();
     params.set("sector", newSector);
-    params.delete("topics");
-    params.delete("techStacks");
+
+    const prevParams = new URLSearchParams(location.search);
+    const searchValue = prevParams.get("search");
+    if (searchValue) {
+      params.set("search", searchValue);
+    }
 
     navigate({ search: params.toString() }, { replace: true });
   };


### PR DESCRIPTION
# 🎯 이슈 번호

close #387 

## ✅ 체크 리스트

- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 🏁 작업 내용

- 직군 탭을 이동할 때 정렬도 함께 초기화되도록 설정했습니다.
- 기존 쿼리 파라미터를 변경하는 방식은 특정 파라미터 key의 value를 삭제하는 방식이였는데 유지보수 관점에서 전체 쿼리 파라미터를 삭제하고 특정 key의 값만 넣는 방식으로 변경했습니다!
