### PR TITLE
refactor(BE): 쿼리 개선을 위한 도메인 구조 변경

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -75,10 +75,11 @@ clean {
 sourceSets {
     main {
         java {
-            srcDir "$buildDir/generated/sources/annotationProcessor/main"
+            srcDir "$buildDir/generated/sources/annotationProcessor/java/main"
         }
     }
 }
+
 
 tasks.named('test', Test) {
     useJUnitPlatform()

--- a/backend/src/main/java/moaon/backend/article/domain/Article.java
+++ b/backend/src/main/java/moaon/backend/article/domain/Article.java
@@ -10,8 +10,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
-import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -25,6 +25,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import moaon.backend.global.domain.BaseTimeEntity;
 import moaon.backend.project.domain.Project;
+import moaon.backend.techStack.domain.ArticleTechStack;
 import moaon.backend.techStack.domain.TechStack;
 
 @Entity
@@ -65,8 +66,8 @@ public class Article extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Project project;
 
-    @ManyToMany
-    private List<TechStack> techStacks;
+    @OneToMany(mappedBy = "article", cascade = jakarta.persistence.CascadeType.ALL, orphanRemoval = true)
+    private List<ArticleTechStack> techStacks;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -86,7 +87,7 @@ public class Article extends BaseTimeEntity {
             Project project,
             Sector sector,
             List<Topic> topics,
-            List<TechStack> techStacks
+            List<ArticleTechStack> techStacks
     ) {
         this.title = title;
         this.summary = summary;
@@ -104,7 +105,14 @@ public class Article extends BaseTimeEntity {
         clicks++;
     }
 
+    public void addTechStack(TechStack techStack) {
+        ArticleTechStack articleTechStack = new ArticleTechStack(this, techStack);
+        this.techStacks.add(articleTechStack);
+    }
+
     public List<TechStack> getTechStacks() {
-        return List.copyOf(techStacks);
+        return techStacks.stream()
+                .map(ArticleTechStack::getTechStack)
+                .toList();
     }
 }

--- a/backend/src/main/java/moaon/backend/article/repository/CustomizedArticleRepositoryImpl.java
+++ b/backend/src/main/java/moaon/backend/article/repository/CustomizedArticleRepositoryImpl.java
@@ -1,6 +1,7 @@
 package moaon.backend.article.repository;
 
 import static moaon.backend.article.domain.QArticle.article;
+import static moaon.backend.techStack.domain.QArticleTechStack.articleTechStack;
 import static moaon.backend.techStack.domain.QTechStack.techStack;
 
 import com.querydsl.core.types.OrderSpecifier;
@@ -44,7 +45,7 @@ public class CustomizedArticleRepositoryImpl implements CustomizedArticleReposit
 
         return jpaQueryFactory
                 .selectFrom(article).distinct()
-                .leftJoin(article.techStacks, techStack)
+                .leftJoin(article.techStacks, articleTechStack)
                 .where(
                         equalSector(sector),
                         containsAllTopics(topics),
@@ -69,7 +70,7 @@ public class CustomizedArticleRepositoryImpl implements CustomizedArticleReposit
         return jpaQueryFactory
                 .select(article.countDistinct())
                 .from(article)
-                .leftJoin(article.techStacks, techStack)
+                .leftJoin(article.techStacks, articleTechStack)
                 .where(
                         equalSector(sector),
                         containsAllTopics(topics),
@@ -89,7 +90,7 @@ public class CustomizedArticleRepositoryImpl implements CustomizedArticleReposit
 
         return jpaQueryFactory.
                 selectFrom(article).distinct()
-                .leftJoin(article.techStacks, techStack)
+                .leftJoin(article.techStacks, articleTechStack)
                 .where(
                         article.project.id.eq(id),
                         equalSector(sector),

--- a/backend/src/main/java/moaon/backend/project/domain/Category.java
+++ b/backend/src/main/java/moaon/backend/project/domain/Category.java
@@ -16,7 +16,7 @@ import lombok.ToString;
 @Getter
 @EqualsAndHashCode(of = "id")
 @ToString
-public class ProjectCategory {
+public class Category {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,7 +25,7 @@ public class ProjectCategory {
     @Column(nullable = false, unique = true)
     private String name;
 
-    public ProjectCategory(String name) {
+    public Category(String name) {
         this.name = name;
     }
 }

--- a/backend/src/main/java/moaon/backend/project/domain/Project.java
+++ b/backend/src/main/java/moaon/backend/project/domain/Project.java
@@ -77,7 +77,7 @@ public class Project extends BaseTimeEntity {
     private List<TechStack> techStacks;
 
     @ManyToMany
-    private List<ProjectCategory> categories;
+    private List<Category> categories;
 
     @OneToMany(mappedBy = "project")
     private List<Article> articles;
@@ -91,7 +91,7 @@ public class Project extends BaseTimeEntity {
             Images images,
             Member author,
             List<TechStack> techStacks,
-            List<ProjectCategory> categories,
+            List<Category> categories,
             LocalDateTime createdAt
     ) {
         this.title = title;
@@ -124,7 +124,7 @@ public class Project extends BaseTimeEntity {
         return List.copyOf(techStacks);
     }
 
-    public List<ProjectCategory> getCategories() {
+    public List<Category> getCategories() {
         return List.copyOf(categories);
     }
 

--- a/backend/src/main/java/moaon/backend/project/domain/Project.java
+++ b/backend/src/main/java/moaon/backend/project/domain/Project.java
@@ -1,5 +1,6 @@
 package moaon.backend.project.domain;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -76,8 +77,8 @@ public class Project extends BaseTimeEntity {
     @ManyToMany
     private List<TechStack> techStacks;
 
-    @ManyToMany
-    private List<Category> categories;
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true) // todo cascade, orphanRemoval 필요?
+    private List<ProjectCategory> categories;
 
     @OneToMany(mappedBy = "project")
     private List<Article> articles;
@@ -91,7 +92,7 @@ public class Project extends BaseTimeEntity {
             Images images,
             Member author,
             List<TechStack> techStacks,
-            List<Category> categories,
+            List<ProjectCategory> categories,
             LocalDateTime createdAt
     ) {
         this.title = title;
@@ -112,6 +113,11 @@ public class Project extends BaseTimeEntity {
         views++;
     }
 
+    public void addCategory(Category category) {
+        ProjectCategory projectCategory = new ProjectCategory(this, category);
+        this.categories.add(projectCategory);
+    }
+
     public int getLoveCount() {
         return lovedMembers.size();
     }
@@ -125,7 +131,9 @@ public class Project extends BaseTimeEntity {
     }
 
     public List<Category> getCategories() {
-        return List.copyOf(categories);
+        return categories.stream()
+                .map(ProjectCategory::getCategory)
+                .toList();
     }
 
     public List<Member> getLovedMembers() {

--- a/backend/src/main/java/moaon/backend/project/domain/Project.java
+++ b/backend/src/main/java/moaon/backend/project/domain/Project.java
@@ -25,6 +25,7 @@ import lombok.ToString;
 import moaon.backend.article.domain.Article;
 import moaon.backend.global.domain.BaseTimeEntity;
 import moaon.backend.member.domain.Member;
+import moaon.backend.techStack.domain.ProjectTechStack;
 import moaon.backend.techStack.domain.TechStack;
 
 @Entity
@@ -74,13 +75,13 @@ public class Project extends BaseTimeEntity {
     @ManyToMany
     private List<Member> lovedMembers;
 
-    @ManyToMany
-    private List<TechStack> techStacks;
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProjectTechStack> techStacks;
 
-    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true) // todo cascade, orphanRemoval 필요?
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ProjectCategory> categories;
 
-    @OneToMany(mappedBy = "project")
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL)
     private List<Article> articles;
 
     public Project(
@@ -91,7 +92,7 @@ public class Project extends BaseTimeEntity {
             String productionUrl,
             Images images,
             Member author,
-            List<TechStack> techStacks,
+            List<ProjectTechStack> techStacks,
             List<ProjectCategory> categories,
             LocalDateTime createdAt
     ) {
@@ -118,6 +119,11 @@ public class Project extends BaseTimeEntity {
         this.categories.add(projectCategory);
     }
 
+    public void addTechStack(TechStack techStack) {
+        ProjectTechStack projectTechStack = new ProjectTechStack(this, techStack);
+        this.techStacks.add(projectTechStack);
+    }
+
     public int getLoveCount() {
         return lovedMembers.size();
     }
@@ -127,7 +133,9 @@ public class Project extends BaseTimeEntity {
     }
 
     public List<TechStack> getTechStacks() {
-        return List.copyOf(techStacks);
+        return techStacks.stream()
+                .map(ProjectTechStack::getTechStack)
+                .toList();
     }
 
     public List<Category> getCategories() {

--- a/backend/src/main/java/moaon/backend/project/domain/ProjectCategory.java
+++ b/backend/src/main/java/moaon/backend/project/domain/ProjectCategory.java
@@ -1,0 +1,36 @@
+package moaon.backend.project.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@EqualsAndHashCode(of = "id")
+@ToString
+public class ProjectCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Category category;
+
+    public ProjectCategory(final Project project, final Category category) {
+        this.project = project;
+        this.category = category;
+    }
+}

--- a/backend/src/main/java/moaon/backend/project/domain/ProjectSortType.java
+++ b/backend/src/main/java/moaon/backend/project/domain/ProjectSortType.java
@@ -27,6 +27,7 @@ public enum ProjectSortType {
             cursor -> CursorParser.toCursor(cursor, new IntegerParser(), LoveProjectCursor::new),
             project -> new LoveProjectCursor(project.getLoveCount(), project.getId())
     ),
+
     ARTICLE_COUNT("articleCount",
             cursor -> CursorParser.toCursor(cursor, new IntegerParser(), ArticleCountProjectCursor::new),
             project -> new ArticleCountProjectCursor(project.getArticles().size(), project.getId())

--- a/backend/src/main/java/moaon/backend/project/dto/ProjectDetailResponse.java
+++ b/backend/src/main/java/moaon/backend/project/dto/ProjectDetailResponse.java
@@ -2,8 +2,8 @@ package moaon.backend.project.dto;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import moaon.backend.project.domain.Category;
 import moaon.backend.project.domain.Project;
-import moaon.backend.project.domain.ProjectCategory;
 import moaon.backend.techStack.domain.TechStack;
 
 public record ProjectDetailResponse(
@@ -34,7 +34,7 @@ public record ProjectDetailResponse(
                         .map(TechStack::getName)
                         .toList(),
                 project.getCategories().stream()
-                        .map(ProjectCategory::getName)
+                        .map(Category::getName)
                         .toList(),
                 project.getImages().getUrls(),
                 false, // TODO 로그인 추가 시 수정

--- a/backend/src/main/java/moaon/backend/project/repository/CategoryRepository.java
+++ b/backend/src/main/java/moaon/backend/project/repository/CategoryRepository.java
@@ -3,5 +3,5 @@ package moaon.backend.project.repository;
 import moaon.backend.project.domain.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ProjectCategoryRepository extends JpaRepository<Category, Long> {
+public interface CategoryRepository extends JpaRepository<Category, Long> {
 }

--- a/backend/src/main/java/moaon/backend/project/repository/CustomizedProjectRepositoryImpl.java
+++ b/backend/src/main/java/moaon/backend/project/repository/CustomizedProjectRepositoryImpl.java
@@ -1,5 +1,6 @@
 package moaon.backend.project.repository;
 
+import static moaon.backend.project.domain.QCategory.category;
 import static moaon.backend.project.domain.QProject.project;
 import static moaon.backend.project.domain.QProjectCategory.projectCategory;
 import static moaon.backend.techStack.domain.QTechStack.techStack;
@@ -95,7 +96,7 @@ public class CustomizedProjectRepositoryImpl implements CustomizedProjectReposit
         if (CollectionUtils.isEmpty(categoryNames)) {
             return null;
         }
-        return projectCategory.name.in(categoryNames);
+        return category.name.in(categoryNames);
     }
 
     private BooleanExpression hasExactTechStackCount(List<String> techStackNames) {
@@ -110,7 +111,7 @@ public class CustomizedProjectRepositoryImpl implements CustomizedProjectReposit
         if (CollectionUtils.isEmpty(categoryNames)) {
             return null;
         }
-        return projectCategory.name.countDistinct()
+        return category.name.countDistinct()
                 .eq((long) categoryNames.size());
     }
 

--- a/backend/src/main/java/moaon/backend/project/repository/CustomizedProjectRepositoryImpl.java
+++ b/backend/src/main/java/moaon/backend/project/repository/CustomizedProjectRepositoryImpl.java
@@ -3,6 +3,7 @@ package moaon.backend.project.repository;
 import static moaon.backend.project.domain.QCategory.category;
 import static moaon.backend.project.domain.QProject.project;
 import static moaon.backend.project.domain.QProjectCategory.projectCategory;
+import static moaon.backend.techStack.domain.QProjectTechStack.projectTechStack;
 import static moaon.backend.techStack.domain.QTechStack.techStack;
 
 import com.querydsl.core.types.OrderSpecifier;
@@ -43,7 +44,7 @@ public class CustomizedProjectRepositoryImpl implements CustomizedProjectReposit
         return jpaQueryFactory
                 .selectFrom(project).distinct()
                 .leftJoin(project.categories, projectCategory)
-                .leftJoin(project.techStacks, techStack)
+                .leftJoin(project.techStacks, projectTechStack)
                 .where(
                         techStackNamesIn(techStackNames),
                         categoryNamesIn(categoryNames),
@@ -70,7 +71,7 @@ public class CustomizedProjectRepositoryImpl implements CustomizedProjectReposit
                 .select(project.countDistinct())
                 .from(project)
                 .leftJoin(project.categories, projectCategory)
-                .leftJoin(project.techStacks, techStack)
+                .leftJoin(project.techStacks, projectTechStack)
                 .where(
                         techStackNamesIn(techStackNames),
                         categoryNamesIn(categoryNames),

--- a/backend/src/main/java/moaon/backend/project/repository/ProjectCategoryRepository.java
+++ b/backend/src/main/java/moaon/backend/project/repository/ProjectCategoryRepository.java
@@ -1,7 +1,7 @@
 package moaon.backend.project.repository;
 
-import moaon.backend.project.domain.ProjectCategory;
+import moaon.backend.project.domain.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ProjectCategoryRepository extends JpaRepository<ProjectCategory, Long> {
+public interface ProjectCategoryRepository extends JpaRepository<Category, Long> {
 }

--- a/backend/src/main/java/moaon/backend/techStack/domain/ArticleTechStack.java
+++ b/backend/src/main/java/moaon/backend/techStack/domain/ArticleTechStack.java
@@ -1,0 +1,37 @@
+package moaon.backend.techStack.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import moaon.backend.article.domain.Article;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@EqualsAndHashCode(of = "id")
+@ToString
+public class ArticleTechStack {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Article article;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private TechStack techStack;
+
+    public ArticleTechStack(Article article, TechStack techStack) {
+        this.article = article;
+        this.techStack = techStack;
+    }
+}

--- a/backend/src/main/java/moaon/backend/techStack/domain/ProjectTechStack.java
+++ b/backend/src/main/java/moaon/backend/techStack/domain/ProjectTechStack.java
@@ -1,4 +1,4 @@
-package moaon.backend.project.domain;
+package moaon.backend.techStack.domain;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -11,13 +11,14 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import moaon.backend.project.domain.Project;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @EqualsAndHashCode(of = "id")
 @ToString
-public class ProjectCategory {
+public class ProjectTechStack {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,10 +28,10 @@ public class ProjectCategory {
     private Project project;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private Category category;
+    private TechStack techStack;
 
-    public ProjectCategory(Project project, Category category) {
+    public ProjectTechStack(Project project, TechStack techStack) {
         this.project = project;
-        this.category = category;
+        this.techStack = techStack;
     }
 }

--- a/backend/src/main/java/moaon/backend/techStack/domain/TechStack.java
+++ b/backend/src/main/java/moaon/backend/techStack/domain/TechStack.java
@@ -5,6 +5,9 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -24,6 +27,12 @@ public class TechStack {
 
     @Column(nullable = false, unique = true)
     private String name;
+
+    @OneToMany(mappedBy = "techStack", cascade = jakarta.persistence.CascadeType.ALL, orphanRemoval = true)
+    private List<ProjectTechStack> projectTechStacks = new ArrayList<>();
+
+    @OneToMany(mappedBy = "techStack", cascade = jakarta.persistence.CascadeType.ALL, orphanRemoval = true)
+    private List<ArticleTechStack> articleTechStacks = new ArrayList<>();
 
     public TechStack(String name) {
         this.name = name;

--- a/backend/src/main/resources/static/docs/index.html
+++ b/backend/src/main/resources/static/docs/index.html
@@ -594,7 +594,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <h4 id="_curl_request"><a class="link" href="#_curl_request">Curl request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'https://api.moaon.site/projects?search=moaon&amp;sort=views&amp;categories=testProjectCategory73&amp;techStacks=testTechStack75&amp;limit=2' -i -X GET</code></pre>
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'https://api.moaon.site/projects?search=moaon&amp;sort=views&amp;categories=testProjectCategory181&amp;techStacks=testTechStack183&amp;limit=2' -i -X GET</code></pre>
 </div>
 </div>
 </div>
@@ -602,7 +602,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <h4 id="_http_request"><a class="link" href="#_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /projects?search=moaon&amp;sort=views&amp;categories=testProjectCategory73&amp;techStacks=testTechStack75&amp;limit=2 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /projects?search=moaon&amp;sort=views&amp;categories=testProjectCategory181&amp;techStacks=testTechStack183&amp;limit=2 HTTP/1.1
 Host: api.moaon.site</code></pre>
 </div>
 </div>
@@ -617,26 +617,26 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Sun, 14 Sep 2025 07:29:26 GMT
+Date: Mon, 22 Sep 2025 08:17:44 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
-Content-Length: 577
+Content-Length: 582
 
 {
   "contents" : [ {
-    "id" : 9,
+    "id" : 11,
     "title" : "moaon",
-    "summary" : "테스트 프로젝트 요약108",
-    "techStacks" : [ "testTechStack75" ],
+    "summary" : "테스트 프로젝트 요약216",
+    "techStacks" : [ "testTechStack183" ],
     "thumbnailUrl" : "https://test.com/image1.png",
     "isLoved" : false,
     "loves" : 0,
     "views" : 6
   }, {
-    "id" : 8,
-    "title" : "테스트 프로젝트 제목101",
+    "id" : 10,
+    "title" : "테스트 프로젝트 제목209",
     "summary" : "moaon",
-    "techStacks" : [ "testTechStack75" ],
+    "techStacks" : [ "testTechStack183" ],
     "thumbnailUrl" : "https://test.com/image1.png",
     "isLoved" : false,
     "loves" : 0,
@@ -644,7 +644,7 @@ Content-Length: 577
   } ],
   "totalCount" : 3,
   "hasNext" : true,
-  "nextCursor" : "4_8"
+  "nextCursor" : "4_10"
 }</code></pre>
 </div>
 </div>
@@ -827,7 +827,7 @@ Content-Length: 577
 <h4 id="_curl_request"><a class="link" href="#_curl_request">Curl request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'https://api.moaon.site/projects/3' -i -X GET</code></pre>
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'https://api.moaon.site/projects/5' -i -X GET</code></pre>
 </div>
 </div>
 </div>
@@ -835,7 +835,7 @@ Content-Length: 577
 <h4 id="_http_request"><a class="link" href="#_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /projects/3 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /projects/5 HTTP/1.1
 Host: api.moaon.site</code></pre>
 </div>
 </div>
@@ -848,27 +848,27 @@ Host: api.moaon.site</code></pre>
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Set-Cookie: viewed_projects=%7B%223%22%3A1757834965%7D; Path=/projects; Max-Age=41435; Expires=Sun, 14 Sep 2025 19:00:00 GMT; Secure; HttpOnly; SameSite=None
+Set-Cookie: viewed_projects=%7B%225%22%3A1758529063%7D; Path=/projects; Max-Age=38537; Expires=Mon, 22 Sep 2025 19:00:00 GMT; Secure; HttpOnly; SameSite=None
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Sun, 14 Sep 2025 07:29:25 GMT
+Date: Mon, 22 Sep 2025 08:17:43 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
-Content-Length: 549
+Content-Length: 553
 
 {
-  "id" : 3,
-  "authorId" : 3,
-  "title" : "테스트 프로젝트 제목67",
-  "summary" : "테스트 프로젝트 요약68",
-  "description" : "테스트 프로젝트 상세 설명69",
-  "techStacks" : [ "testTechStack71" ],
-  "categories" : [ "testProjectCategory72" ],
+  "id" : 5,
+  "authorId" : 5,
+  "title" : "테스트 프로젝트 제목175",
+  "summary" : "테스트 프로젝트 요약176",
+  "description" : "테스트 프로젝트 상세 설명177",
+  "techStacks" : [ "testTechStack179" ],
+  "categories" : [ "testProjectCategory180" ],
   "imageUrls" : [ "https://test.com/image1.png", "https://test.com/image2.png" ],
   "isLoved" : false,
   "loves" : 0,
   "views" : 1,
-  "createdAt" : "2025-09-14T16:29:24.992844",
+  "createdAt" : "2025-09-22T17:17:43.56796",
   "githubUrl" : "https://github.com/test-repo",
   "productionUrl" : "https://test-product.com"
 }</code></pre>
@@ -1007,7 +1007,7 @@ Content-Length: 549
 <h4 id="_curl_request"><a class="link" href="#_curl_request">Curl request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'https://api.moaon.site/projects/1/articles?sector=be&amp;search=%EB%AA%A8%EC%95%84%EC%98%A8' -i -X GET</code></pre>
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'https://api.moaon.site/projects/3/articles?sector=be&amp;search=%EB%AA%A8%EC%95%84%EC%98%A8' -i -X GET</code></pre>
 </div>
 </div>
 </div>
@@ -1015,7 +1015,7 @@ Content-Length: 549
 <h4 id="_http_request"><a class="link" href="#_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /projects/1/articles?sector=be&amp;search=%EB%AA%A8%EC%95%84%EC%98%A8 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /projects/3/articles?sector=be&amp;search=%EB%AA%A8%EC%95%84%EC%98%A8 HTTP/1.1
 Host: api.moaon.site</code></pre>
 </div>
 </div>
@@ -1030,27 +1030,27 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Sun, 14 Sep 2025 07:29:24 GMT
+Date: Mon, 22 Sep 2025 08:17:43 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
-Content-Length: 1249
+Content-Length: 1259
 
 {
   "counts" : [ {
-    "sector" : "infra",
+    "sector" : "fe",
+    "count" : 1
+  }, {
+    "sector" : "android",
     "count" : 0
   }, {
     "sector" : "ios",
     "count" : 0
   }, {
-    "sector" : "android",
+    "sector" : "infra",
     "count" : 0
   }, {
     "sector" : "nonTech",
     "count" : 0
-  }, {
-    "sector" : "fe",
-    "count" : 1
   }, {
     "sector" : "be",
     "count" : 4
@@ -1059,35 +1059,35 @@ Content-Length: 1249
     "count" : 5
   } ],
   "articles" : [ {
-    "id" : 1,
+    "id" : 11,
     "title" : "모아온",
-    "summary" : "테스트 아티클 요약8",
+    "summary" : "테스트 아티클 요약116",
     "clicks" : 0,
-    "techStacks" : [ "testTechStack16" ],
+    "techStacks" : [ "testTechStack124" ],
     "url" : "https://test-product.com",
     "sector" : "be",
     "topics" : [ "etc" ],
-    "createdAt" : "2025-09-14T16:29:18.127891"
+    "createdAt" : "2025-09-22T17:17:43.01026"
   }, {
-    "id" : 2,
-    "title" : "테스트 아티클 제목17",
+    "id" : 12,
+    "title" : "테스트 아티클 제목125",
     "summary" : "모아온",
     "clicks" : 0,
-    "techStacks" : [ "testTechStack26" ],
+    "techStacks" : [ "testTechStack134" ],
     "url" : "https://test-product.com",
     "sector" : "be",
     "topics" : [ "etc" ],
-    "createdAt" : "2025-09-14T16:29:18.237552"
+    "createdAt" : "2025-09-22T17:17:43.052172"
   }, {
-    "id" : 3,
-    "title" : "테스트 아티클 제목27",
-    "summary" : "테스트 아티클 요약28",
+    "id" : 13,
+    "title" : "테스트 아티클 제목135",
+    "summary" : "테스트 아티클 요약136",
     "clicks" : 0,
-    "techStacks" : [ "testTechStack36" ],
+    "techStacks" : [ "testTechStack144" ],
     "url" : "https://test-product.com",
     "sector" : "be",
     "topics" : [ "etc" ],
-    "createdAt" : "2025-09-14T16:29:18.279264"
+    "createdAt" : "2025-09-22T17:17:43.095366"
   } ]
 }</code></pre>
 </div>
@@ -1253,7 +1253,7 @@ Content-Length: 1249
 <h4 id="_curl_request"><a class="link" href="#_curl_request">Curl request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'https://api.moaon.site/articles?sort=clicks&amp;search=moa&amp;sector=be&amp;topics=db&amp;techStacks=testTechStack113&amp;limit=2&amp;cursor=5_6' -i -X GET</code></pre>
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'https://api.moaon.site/articles?sort=clicks&amp;search=moa&amp;sector=be&amp;topics=db&amp;techStacks=testTechStack1&amp;limit=2&amp;cursor=5_6' -i -X GET</code></pre>
 </div>
 </div>
 </div>
@@ -1261,7 +1261,7 @@ Content-Length: 1249
 <h4 id="_http_request"><a class="link" href="#_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /articles?sort=clicks&amp;search=moa&amp;sector=be&amp;topics=db&amp;techStacks=testTechStack113&amp;limit=2&amp;cursor=5_6 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /articles?sort=clicks&amp;search=moa&amp;sector=be&amp;topics=db&amp;techStacks=testTechStack1&amp;limit=2&amp;cursor=5_6 HTTP/1.1
 Host: api.moaon.site</code></pre>
 </div>
 </div>
@@ -1276,36 +1276,36 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Sun, 14 Sep 2025 07:29:31 GMT
+Date: Mon, 22 Sep 2025 08:17:41 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
-Content-Length: 837
+Content-Length: 826
 
 {
   "contents" : [ {
     "id" : 9,
     "projectId" : 1,
-    "projectTitle" : "테스트 프로젝트 제목115",
+    "projectTitle" : "테스트 프로젝트 제목3",
     "clicks" : 3,
-    "title" : "테스트 아티클 제목201",
-    "summary" : "테스트 아티클 요약202",
-    "techStacks" : [ "testTechStack113" ],
+    "title" : "테스트 아티클 제목89",
+    "summary" : "테스트 아티클 요약90",
+    "techStacks" : [ "testTechStack1" ],
     "url" : "https://test-product.com",
     "sector" : "be",
     "topics" : [ "db" ],
-    "createdAt" : "2025-09-14T16:29:30.313166"
+    "createdAt" : "2025-09-22T17:17:38.667565"
   }, {
     "id" : 8,
     "projectId" : 1,
-    "projectTitle" : "테스트 프로젝트 제목115",
+    "projectTitle" : "테스트 프로젝트 제목3",
     "clicks" : 2,
     "title" : "moa",
-    "summary" : "테스트 아티클 요약192",
-    "techStacks" : [ "testTechStack113" ],
+    "summary" : "테스트 아티클 요약80",
+    "techStacks" : [ "testTechStack1" ],
     "url" : "https://test-product.com",
     "sector" : "be",
     "topics" : [ "db" ],
-    "createdAt" : "2025-09-14T16:29:30.284467"
+    "createdAt" : "2025-09-22T17:17:38.602641"
   } ],
   "totalCount" : 3,
   "hasNext" : true,
@@ -1535,8 +1535,8 @@ Host: api.moaon.site</code></pre>
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Set-Cookie: clicked_articles=%7B%2210%22%3A1757834971%7D; Path=/articles; Max-Age=41429; Expires=Sun, 14 Sep 2025 19:00:00 GMT; Secure; HttpOnly; SameSite=None
-Date: Sun, 14 Sep 2025 07:29:31 GMT
+Set-Cookie: clicked_articles=%7B%2210%22%3A1758529062%7D; Path=/articles; Max-Age=38538; Expires=Mon, 22 Sep 2025 19:00:00 GMT; Secure; HttpOnly; SameSite=None
+Date: Mon, 22 Sep 2025 08:17:42 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive</code></pre>
 </div>

--- a/backend/src/test/java/moaon/backend/api/project/ProjectApiTest.java
+++ b/backend/src/test/java/moaon/backend/api/project/ProjectApiTest.java
@@ -21,8 +21,8 @@ import moaon.backend.fixture.Fixture;
 import moaon.backend.fixture.ProjectFixtureBuilder;
 import moaon.backend.fixture.RepositoryHelper;
 import moaon.backend.global.config.QueryDslConfig;
+import moaon.backend.project.domain.Category;
 import moaon.backend.project.domain.Project;
-import moaon.backend.project.domain.ProjectCategory;
 import moaon.backend.project.dto.PagedProjectResponse;
 import moaon.backend.project.dto.ProjectArticleResponse;
 import moaon.backend.project.dto.ProjectDetailResponse;
@@ -88,50 +88,50 @@ public class ProjectApiTest extends BaseApiTest {
         // given
         String filteredSearch = "moaon";
         String unfilteredSearch = "momoon";
-        ProjectCategory filteredProjectCategory = Fixture.anyProjectCategory();
-        ProjectCategory unfilteredProjectCategory = Fixture.anyProjectCategory();
+        Category filteredCategory = Fixture.anyProjectCategory();
+        Category unfilteredCategory = Fixture.anyProjectCategory();
         TechStack filteredTechStack = Fixture.anyTechStack();
         TechStack unfilteredTechStack = Fixture.anyTechStack();
 
         repositoryHelper.save(
                 new ProjectFixtureBuilder()
                         .description(unfilteredSearch)
-                        .categories(filteredProjectCategory)
+                        .categories(filteredCategory)
                         .techStacks(filteredTechStack)
                         .build()
         );
         repositoryHelper.save(
                 new ProjectFixtureBuilder()
                         .description(filteredSearch)
-                        .categories(unfilteredProjectCategory)
+                        .categories(unfilteredCategory)
                         .techStacks(filteredTechStack)
                         .build()
         );
         repositoryHelper.save(
                 new ProjectFixtureBuilder()
                         .description(filteredSearch)
-                        .categories(filteredProjectCategory)
+                        .categories(filteredCategory)
                         .techStacks(unfilteredTechStack)
                         .build()
         );
 
         Project projectViewRankThird = repositoryHelper.save(new ProjectFixtureBuilder()
                 .description(filteredSearch)
-                .categories(filteredProjectCategory)
+                .categories(filteredCategory)
                 .techStacks(filteredTechStack)
                 .views(1)
                 .build()
         );
         Project projectViewRankSecond = repositoryHelper.save(new ProjectFixtureBuilder()
                 .summary(filteredSearch)
-                .categories(filteredProjectCategory)
+                .categories(filteredCategory)
                 .techStacks(filteredTechStack)
                 .views(2)
                 .build()
         );
         Project projectViewRankFirst = repositoryHelper.save(new ProjectFixtureBuilder()
                 .title(filteredSearch)
-                .categories(filteredProjectCategory)
+                .categories(filteredCategory)
                 .techStacks(filteredTechStack)
                 .views(3)
                 .build()
@@ -141,7 +141,7 @@ public class ProjectApiTest extends BaseApiTest {
         PagedProjectResponse actualResponses = RestAssured.given(documentationSpecification).log().all()
                 .queryParams("search", filteredSearch)
                 .queryParams("sort", "views")
-                .queryParams("categories", List.of(filteredProjectCategory.getName()))
+                .queryParams("categories", List.of(filteredCategory.getName()))
                 .queryParams("techStacks", List.of(filteredTechStack.getName()))
                 .queryParams("limit", 2)
                 .filter(document(projectQueryParameters(), pagedProjectResponseFields()))

--- a/backend/src/test/java/moaon/backend/fixture/ArticleFixtureBuilder.java
+++ b/backend/src/test/java/moaon/backend/fixture/ArticleFixtureBuilder.java
@@ -93,7 +93,7 @@ public class ArticleFixtureBuilder {
     }
 
     public Article build() {
-        return Article.builder()
+        Article article = Article.builder()
                 .id(this.id)
                 .title(this.title)
                 .summary(this.summary)
@@ -104,7 +104,13 @@ public class ArticleFixtureBuilder {
                 .project(this.project)
                 .sector(this.sector)
                 .topics(this.topics)
-                .techStacks(this.techStacks)
+                .techStacks(new ArrayList<>())
                 .build();
+        
+        for (TechStack techStack : techStacks) {
+            article.addTechStack(techStack);
+        }
+        
+        return article;
     }
 }

--- a/backend/src/test/java/moaon/backend/fixture/Fixture.java
+++ b/backend/src/test/java/moaon/backend/fixture/Fixture.java
@@ -4,7 +4,7 @@ import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 import moaon.backend.article.domain.Sector;
 import moaon.backend.member.domain.Member;
-import moaon.backend.project.domain.ProjectCategory;
+import moaon.backend.project.domain.Category;
 import moaon.backend.techStack.domain.TechStack;
 
 public class Fixture {
@@ -19,8 +19,8 @@ public class Fixture {
         return new TechStack(nameWithSequence("testTechStack"));
     }
 
-    public static ProjectCategory anyProjectCategory() {
-        return new ProjectCategory(nameWithSequence("testProjectCategory"));
+    public static Category anyProjectCategory() {
+        return new Category(nameWithSequence("testProjectCategory"));
     }
 
     public static Sector randomSector() {

--- a/backend/src/test/java/moaon/backend/fixture/ProjectFixtureBuilder.java
+++ b/backend/src/test/java/moaon/backend/fixture/ProjectFixtureBuilder.java
@@ -6,9 +6,9 @@ import java.util.Arrays;
 import java.util.List;
 import moaon.backend.article.domain.Article;
 import moaon.backend.member.domain.Member;
+import moaon.backend.project.domain.Category;
 import moaon.backend.project.domain.Images;
 import moaon.backend.project.domain.Project;
-import moaon.backend.project.domain.ProjectCategory;
 import moaon.backend.techStack.domain.TechStack;
 
 public class ProjectFixtureBuilder {
@@ -22,7 +22,7 @@ public class ProjectFixtureBuilder {
     private Images images;
     private Member author;
     private List<TechStack> techStacks;
-    private List<ProjectCategory> categories;
+    private List<Category> categories;
     private LocalDateTime createdAt;
     private int views = 0;
     private List<Member> lovedMembers;
@@ -88,7 +88,7 @@ public class ProjectFixtureBuilder {
         return this;
     }
 
-    public ProjectFixtureBuilder categories(ProjectCategory... categories) {
+    public ProjectFixtureBuilder categories(Category... categories) {
         this.categories = new ArrayList<>(Arrays.asList(categories));
         return this;
     }

--- a/backend/src/test/java/moaon/backend/fixture/ProjectFixtureBuilder.java
+++ b/backend/src/test/java/moaon/backend/fixture/ProjectFixtureBuilder.java
@@ -113,7 +113,7 @@ public class ProjectFixtureBuilder {
                 .lovedMembers(this.lovedMembers)
                 .createdAt(this.createdAt)
                 .summary(this.summary)
-                .categories(this.categories)
+                .categories(new ArrayList<>())
                 .description(this.description)
                 .githubUrl(this.githubUrl)
                 .images(this.images)
@@ -122,6 +122,9 @@ public class ProjectFixtureBuilder {
                 .build();
         for (int i = 0; i < views; i++) {
             project.addViewCount();
+        }
+        for (Category category : categories) {
+            project.addCategory(category);
         }
         return project;
     }

--- a/backend/src/test/java/moaon/backend/fixture/ProjectFixtureBuilder.java
+++ b/backend/src/test/java/moaon/backend/fixture/ProjectFixtureBuilder.java
@@ -117,14 +117,19 @@ public class ProjectFixtureBuilder {
                 .description(this.description)
                 .githubUrl(this.githubUrl)
                 .images(this.images)
-                .techStacks(this.techStacks)
+                .techStacks(new ArrayList<>())
                 .articles(this.articles)
                 .build();
-        for (int i = 0; i < views; i++) {
-            project.addViewCount();
-        }
+
         for (Category category : categories) {
             project.addCategory(category);
+        }
+        for (TechStack techStack : techStacks) {
+            project.addTechStack(techStack);
+        }
+
+        for (int i = 0; i < views; i++) {
+            project.addViewCount();
         }
         return project;
     }

--- a/backend/src/test/java/moaon/backend/fixture/RepositoryHelper.java
+++ b/backend/src/test/java/moaon/backend/fixture/RepositoryHelper.java
@@ -4,7 +4,7 @@ import moaon.backend.article.domain.Article;
 import moaon.backend.article.repository.ArticleRepository;
 import moaon.backend.member.repository.MemberRepository;
 import moaon.backend.project.domain.Project;
-import moaon.backend.project.repository.ProjectCategoryRepository;
+import moaon.backend.project.repository.CategoryRepository;
 import moaon.backend.project.repository.ProjectRepository;
 import moaon.backend.techStack.repository.TechStackRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,7 +20,7 @@ public class RepositoryHelper {
     private TechStackRepository techStackRepository;
 
     @Autowired
-    private ProjectCategoryRepository projectCategoryRepository;
+    private CategoryRepository categoryRepository;
 
     @Autowired
     private ProjectRepository projectRepository;
@@ -31,7 +31,7 @@ public class RepositoryHelper {
     public Project save(Project project) {
         memberRepository.save(project.getAuthor());
         techStackRepository.saveAll(project.getTechStacks());
-        projectCategoryRepository.saveAll(project.getCategories());
+        categoryRepository.saveAll(project.getCategories());
 
         return projectRepository.save(project);
     }

--- a/backend/src/test/java/moaon/backend/project/repository/CustomizedProjectRepositoryImplTest.java
+++ b/backend/src/test/java/moaon/backend/project/repository/CustomizedProjectRepositoryImplTest.java
@@ -11,8 +11,8 @@ import moaon.backend.fixture.ProjectQueryConditionFixtureBuilder;
 import moaon.backend.fixture.RepositoryHelper;
 import moaon.backend.global.config.QueryDslConfig;
 import moaon.backend.member.domain.Member;
+import moaon.backend.project.domain.Category;
 import moaon.backend.project.domain.Project;
-import moaon.backend.project.domain.ProjectCategory;
 import moaon.backend.project.domain.ProjectSortType;
 import moaon.backend.project.dto.ProjectQueryCondition;
 import moaon.backend.techStack.domain.TechStack;
@@ -55,22 +55,22 @@ class CustomizedProjectRepositoryImplTest {
     @Test
     void findWithCategoryFilter() {
         // given
-        ProjectCategory projectCategory1 = Fixture.anyProjectCategory();
-        ProjectCategory projectCategory2 = Fixture.anyProjectCategory();
-        ProjectCategory projectCategory3 = Fixture.anyProjectCategory();
-        ProjectCategory projectCategory4 = Fixture.anyProjectCategory();
-        ProjectCategory projectCategory5 = Fixture.anyProjectCategory();
+        Category category1 = Fixture.anyProjectCategory();
+        Category category2 = Fixture.anyProjectCategory();
+        Category category3 = Fixture.anyProjectCategory();
+        Category category4 = Fixture.anyProjectCategory();
+        Category category5 = Fixture.anyProjectCategory();
 
         repositoryHelper.save(new ProjectFixtureBuilder()
-                .categories(projectCategory1, projectCategory2)
+                .categories(category1, category2)
                 .build()
         );
         repositoryHelper.save(new ProjectFixtureBuilder()
-                .categories(projectCategory2, projectCategory3)
+                .categories(category2, category3)
                 .build()
         );
         Project projectWantToFind = repositoryHelper.save(new ProjectFixtureBuilder()
-                .categories(projectCategory1, projectCategory3, projectCategory4, projectCategory5)
+                .categories(category1, category3, category4, category5)
                 .build()
         );
 
@@ -78,10 +78,10 @@ class CustomizedProjectRepositoryImplTest {
         List<Project> projects = customizedProjectRepositoryImpl.findWithSearchConditions(
                 new ProjectQueryConditionFixtureBuilder()
                         .categoryNames(
-                                projectCategory1.getName(),
-                                projectCategory3.getName(),
-                                projectCategory4.getName(),
-                                projectCategory5.getName())
+                                category1.getName(),
+                                category3.getName(),
+                                category4.getName(),
+                                category5.getName())
                         .build()
         );
 
@@ -128,36 +128,36 @@ class CustomizedProjectRepositoryImplTest {
     @Test
     void findWithTechStackFilterAndCategory() {
         // given
-        ProjectCategory projectCategory1 = Fixture.anyProjectCategory();
-        ProjectCategory projectCategory2 = Fixture.anyProjectCategory();
-        ProjectCategory projectCategory3 = Fixture.anyProjectCategory();
+        Category category1 = Fixture.anyProjectCategory();
+        Category category2 = Fixture.anyProjectCategory();
+        Category category3 = Fixture.anyProjectCategory();
 
         TechStack techStack1 = Fixture.anyTechStack();
         TechStack techStack2 = Fixture.anyTechStack();
 
         Project wantToFindProject = repositoryHelper.save(
                 new ProjectFixtureBuilder()
-                        .categories(projectCategory1, projectCategory2, projectCategory3)
+                        .categories(category1, category2, category3)
                         .techStacks(techStack1, techStack2)
                         .build()
         );
 
         repositoryHelper.save(
                 new ProjectFixtureBuilder()
-                        .categories(projectCategory1, projectCategory2)
+                        .categories(category1, category2)
                         .techStacks(techStack1, techStack2)
                         .build()
         );
 
         repositoryHelper.save(
                 new ProjectFixtureBuilder()
-                        .categories(projectCategory1, projectCategory2, projectCategory3)
+                        .categories(category1, category2, category3)
                         .techStacks(techStack1)
                         .build()
         );
 
         ProjectQueryCondition queryCondition = new ProjectQueryConditionFixtureBuilder()
-                .categoryNames(projectCategory1.getName(), projectCategory2.getName(), projectCategory3.getName())
+                .categoryNames(category1.getName(), category2.getName(), category3.getName())
                 .techStackNames(techStack1.getName(), techStack2.getName())
                 .build();
 
@@ -282,36 +282,36 @@ class CustomizedProjectRepositoryImplTest {
     @Test
     void countWithSearchCondition() {
         // given
-        ProjectCategory projectCategory1 = Fixture.anyProjectCategory();
-        ProjectCategory projectCategory2 = Fixture.anyProjectCategory();
-        ProjectCategory projectCategory3 = Fixture.anyProjectCategory();
+        Category category1 = Fixture.anyProjectCategory();
+        Category category2 = Fixture.anyProjectCategory();
+        Category category3 = Fixture.anyProjectCategory();
 
         TechStack techStack1 = Fixture.anyTechStack();
         TechStack techStack2 = Fixture.anyTechStack();
 
         Project wantToFindProject1 = repositoryHelper.save(
                 new ProjectFixtureBuilder()
-                        .categories(projectCategory1, projectCategory2, projectCategory3)
+                        .categories(category1, category2, category3)
                         .techStacks(techStack1, techStack2)
                         .build()
         );
 
         Project wantToFindProject2 = repositoryHelper.save(
                 new ProjectFixtureBuilder()
-                        .categories(projectCategory1, projectCategory2, projectCategory3)
+                        .categories(category1, category2, category3)
                         .techStacks(techStack1, techStack2)
                         .build()
         );
 
         Project wantToFindProject3 = repositoryHelper.save(
                 new ProjectFixtureBuilder()
-                        .categories(projectCategory1, projectCategory2, projectCategory3)
+                        .categories(category1, category2, category3)
                         .techStacks(techStack1, techStack2)
                         .build()
         );
 
         ProjectQueryCondition queryCondition = new ProjectQueryConditionFixtureBuilder()
-                .categoryNames(projectCategory1.getName(), projectCategory2.getName(), projectCategory3.getName())
+                .categoryNames(category1.getName(), category2.getName(), category3.getName())
                 .techStackNames(techStack1.getName(), techStack2.getName())
                 .build();
 


### PR DESCRIPTION
# 🎯 이슈 번호

- #391 
- 다음 PR에서 쿼리를 수정할 예정이라 이슈는 닫지 않고 두겠습니다.

## ✅ 체크 리스트

- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 🏁 작업 내용

- 중간 엔티티 생성
  - `ProjectCategory`
  - `ProjectTechStack`
  - `ArticleTechStack`
- `project_loved_members`나 `project_urls`(이미지 url 테이블) 처럼 조회 직접적으로 사용되지 않는 도메인은 일단 변경하지 않았습니다.

## 🎸 기타

- `build.gradle`의 `sourceSets` 설정에 오타가 있어서 수정했습니다. 코드 풀 받아서 컴파일 잘 돌아가는지 한 번씩 확인해주세요! 만약 안되면 [인텔리제이 캐시 지우고](https://ryuuun.tistory.com/31) 다시 돌려보세요.
  ```
  ./gradlew clean compileJava
  ```
- `OneToMany` 연관관계에 편의를 위해 다음과 같은 옵션을 추가했습니다. 이 부분도 확인해주세요!
    ```java
        @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
        private List<ProjectTechStack> techStacks;
    
        @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
        private List<ProjectCategory> categories;
    
        @OneToMany(mappedBy = "project", cascade = CascadeType.ALL)
        private List<Article> articles;
    ```