### PR TITLE
refactor(BE): 아티클 쿼리 속도 개선

### DIFF
--- a/backend/src/main/java/moaon/backend/article/repository/CustomizedArticleRepository.java
+++ b/backend/src/main/java/moaon/backend/article/repository/CustomizedArticleRepository.java
@@ -12,4 +12,16 @@ public interface CustomizedArticleRepository {
     long countWithSearchCondition(ArticleQueryCondition queryCondition);
 
     List<Article> findAllByProjectIdAndCondition(long id, ProjectArticleQueryCondition condition);
+
+    List<Article> findWithTechStackFilter(ArticleQueryCondition queryCondition);
+
+    List<Article> findWithTopicFilter(ArticleQueryCondition queryCondition);
+
+    List<Article> findWithBasicFilter(ArticleQueryCondition queryCondition);
+
+    long countWithTechStackFilter(ArticleQueryCondition queryCondition);
+
+    long countWithTopicFilter(ArticleQueryCondition queryCondition);
+
+    long countWithBasicFilter(ArticleQueryCondition queryCondition);
 }

--- a/backend/src/main/java/moaon/backend/article/repository/CustomizedArticleRepository.java
+++ b/backend/src/main/java/moaon/backend/article/repository/CustomizedArticleRepository.java
@@ -12,16 +12,4 @@ public interface CustomizedArticleRepository {
     long countWithSearchCondition(ArticleQueryCondition queryCondition);
 
     List<Article> findAllByProjectIdAndCondition(long id, ProjectArticleQueryCondition condition);
-
-    List<Article> findWithTechStackFilter(ArticleQueryCondition queryCondition);
-
-    List<Article> findWithTopicFilter(ArticleQueryCondition queryCondition);
-
-    List<Article> findWithBasicFilter(ArticleQueryCondition queryCondition);
-
-    long countWithTechStackFilter(ArticleQueryCondition queryCondition);
-
-    long countWithTopicFilter(ArticleQueryCondition queryCondition);
-
-    long countWithBasicFilter(ArticleQueryCondition queryCondition);
 }

--- a/backend/src/main/java/moaon/backend/article/repository/CustomizedArticleRepositoryImpl.java
+++ b/backend/src/main/java/moaon/backend/article/repository/CustomizedArticleRepositoryImpl.java
@@ -40,10 +40,25 @@ public class CustomizedArticleRepositoryImpl implements CustomizedArticleReposit
         if (hasTechStackFilter(queryCondition)) {
             return findWithTechStackFilter(queryCondition);
         }
-        if (hasTopicFilter(queryCondition)) {
-            return findWithTopicFilter(queryCondition);
-        }
-        return findWithBasicFilter(queryCondition);
+
+        SearchKeyword searchKeyword = queryCondition.search();
+        Sector sector = queryCondition.sector();
+        ArticleSortType sortBy = queryCondition.sortBy();
+        Cursor<?> articleCursor = queryCondition.articleCursor();
+        List<Topic> topics = queryCondition.topics();
+        int limit = queryCondition.limit();
+
+        return jpaQueryFactory
+                .selectFrom(article)
+                .where(
+                        equalSector(sector),
+                        applyCursor(articleCursor),
+                        satisfiesMatchScore(searchKeyword),
+                        containsAllTopics(topics)
+                )
+                .orderBy(toOrderByWithSector(sortBy, sector))
+                .limit(limit + FETCH_EXTRA_FOR_HAS_NEXT)
+                .fetch();
     }
 
     @Override
@@ -51,10 +66,18 @@ public class CustomizedArticleRepositoryImpl implements CustomizedArticleReposit
         if (hasTechStackFilter(queryCondition)) {
             return countWithTechStackFilter(queryCondition);
         }
-        if (hasTopicFilter(queryCondition)) {
-            return countWithTopicFilter(queryCondition);
-        }
-        return countWithBasicFilter(queryCondition);
+
+        SearchKeyword searchKeyword = queryCondition.search();
+        Sector sector = queryCondition.sector();
+
+        return jpaQueryFactory
+                .select(article.count())
+                .from(article)
+                .where(
+                        equalSector(sector),
+                        satisfiesMatchScore(searchKeyword)
+                )
+                .fetchOne();
     }
 
     @Override
@@ -73,111 +96,36 @@ public class CustomizedArticleRepositoryImpl implements CustomizedArticleReposit
                 .fetch();
     }
 
-    @Override
-    public List<Article> findWithTechStackFilter(ArticleQueryCondition queryCondition) {
-        String selectClause = String.join("\n",
+    private List<Article> findWithTechStackFilter(ArticleQueryCondition queryCondition) {
+        String sql = String.join("\n",
                 "SELECT a1_0.id, a1_0.article_url, a1_0.clicks, a1_0.content,",
                 "a1_0.created_at, a1_0.project_id, a1_0.sector, a1_0.summary,",
-                "a1_0.title, a1_0.updated_at");
-
-        String sql = String.join("\n",
-                selectClause,
-                buildCommonTechStackQuery(queryCondition),
+                "a1_0.title, a1_0.updated_at",
+                buildFromAndJoinClause(),
+                buildWhereClause(queryCondition),
                 buildOrderByClause(queryCondition),
-                "LIMIT :limit");
+                "LIMIT :limit"
+        );
 
         Query query = entityManager.createNativeQuery(sql, Article.class);
-        setCommonTechStackParameters(query, queryCondition);
+        setTechStackParameters(query, queryCondition);
         query.setParameter("limit", queryCondition.limit() + FETCH_EXTRA_FOR_HAS_NEXT);
 
         return query.getResultList();
     }
 
-    @Override
-    public long countWithTechStackFilter(ArticleQueryCondition queryCondition) {
-        String sql = String.join(" ",
+    private long countWithTechStackFilter(ArticleQueryCondition queryCondition) {
+        String sql = String.join("\n",
                 "SELECT COUNT(*)",
-                buildCommonTechStackQuery(queryCondition));
+                buildFromAndJoinClause(),
+                buildWhereClause(queryCondition)
+        );
 
         Query query = entityManager.createNativeQuery(sql);
-        setCommonTechStackParameters(query, queryCondition);
+        setTechStackParameters(query, queryCondition);
 
         Object result = query.getSingleResult();
         return ((Number) result).longValue();
-    }
-
-    @Override
-    public List<Article> findWithTopicFilter(ArticleQueryCondition queryCondition) {
-        SearchKeyword searchKeyword = queryCondition.search();
-        Sector sector = queryCondition.sector();
-        List<Topic> topics = queryCondition.topics();
-        ArticleSortType sortBy = queryCondition.sortBy();
-        Cursor<?> articleCursor = queryCondition.articleCursor();
-        int limit = queryCondition.limit();
-
-        return jpaQueryFactory
-                .selectFrom(article)
-                .where(
-                        equalSector(sector),
-                        applyCursor(articleCursor),
-                        satisfiesMatchScore(searchKeyword),
-                        containsAllTopics(topics)
-                )
-                .orderBy(toOrderByWithSector(sortBy, sector))
-                .limit(limit + FETCH_EXTRA_FOR_HAS_NEXT)
-                .fetch();
-    }
-
-    @Override
-    public long countWithTopicFilter(ArticleQueryCondition queryCondition) {
-        SearchKeyword searchKeyword = queryCondition.search();
-        Sector sector = queryCondition.sector();
-        List<Topic> topics = queryCondition.topics();
-
-        return jpaQueryFactory
-                .select(article.count())
-                .from(article)
-                .where(
-                        equalSector(sector),
-                        containsAllTopics(topics),
-                        satisfiesMatchScore(searchKeyword)
-                )
-                .fetchOne();
-    }
-
-    @Override
-    public List<Article> findWithBasicFilter(ArticleQueryCondition queryCondition) {
-        SearchKeyword searchKeyword = queryCondition.search();
-        Sector sector = queryCondition.sector();
-        ArticleSortType sortBy = queryCondition.sortBy();
-        Cursor<?> articleCursor = queryCondition.articleCursor();
-        int limit = queryCondition.limit();
-
-        return jpaQueryFactory
-                .selectFrom(article)
-                .where(
-                        equalSector(sector),
-                        applyCursor(articleCursor),
-                        satisfiesMatchScore(searchKeyword)
-                )
-                .orderBy(toOrderByWithSector(sortBy, sector))
-                .limit(limit + FETCH_EXTRA_FOR_HAS_NEXT)
-                .fetch();
-    }
-
-    @Override
-    public long countWithBasicFilter(ArticleQueryCondition queryCondition) {
-        SearchKeyword searchKeyword = queryCondition.search();
-        Sector sector = queryCondition.sector();
-
-        return jpaQueryFactory
-                .select(article.count())
-                .from(article)
-                .where(
-                        equalSector(sector),
-                        satisfiesMatchScore(searchKeyword)
-                )
-                .fetchOne();
     }
 
     private BooleanExpression equalSector(Sector sector) {
@@ -186,7 +134,6 @@ public class CustomizedArticleRepositoryImpl implements CustomizedArticleReposit
         }
         return article.sector.eq(sector);
     }
-
 
     private BooleanExpression containsAllTopics(List<Topic> topics) {
         if (CollectionUtils.isEmpty(topics)) {
@@ -197,7 +144,6 @@ public class CustomizedArticleRepositoryImpl implements CustomizedArticleReposit
                 .reduce(BooleanExpression::and)
                 .orElse(null);
     }
-
 
     private BooleanExpression satisfiesMatchScore(SearchKeyword searchKeyword) {
         if (searchKeyword == null || !searchKeyword.hasValue()) {
@@ -265,52 +211,60 @@ public class CustomizedArticleRepositoryImpl implements CustomizedArticleReposit
         return !CollectionUtils.isEmpty(queryCondition.techStackNames());
     }
 
-    private boolean hasTopicFilter(ArticleQueryCondition queryCondition) {
-        return !CollectionUtils.isEmpty(queryCondition.topics());
+    private String buildFromAndJoinClause() {
+        return "FROM article a1_0 " +
+                "JOIN ( " +
+                "    SELECT ts1_0.article_id " +
+                "    FROM article_tech_stack ts1_0 " +
+                "    JOIN tech_stack ts2_0 ON ts2_0.id = ts1_0.tech_stack_id " +
+                "    WHERE ts2_0.name IN (:techStackNames) " +
+                "    GROUP BY ts1_0.article_id " +
+                "    HAVING COUNT(DISTINCT ts1_0.tech_stack_id) = :techStackCount " +
+                ") AS filtered_articles ON a1_0.id = filtered_articles.article_id " +
+                "WHERE 1=1 ";
     }
 
-    private String buildCommonTechStackQuery(ArticleQueryCondition queryCondition) {
+    private String buildWhereClause(ArticleQueryCondition queryCondition) {
         SearchKeyword searchKeyword = queryCondition.search();
         Sector sector = queryCondition.sector();
         ArticleSortType sortBy = queryCondition.sortBy();
         Cursor<?> articleCursor = queryCondition.articleCursor();
+        List<Topic> topics = queryCondition.topics();
 
-        StringBuilder sql = new StringBuilder(300);
-        sql.append("FROM article a1_0 ")
-                .append("JOIN ( ")
-                .append("    SELECT ts1_0.article_id ")
-                .append("    FROM article_tech_stack ts1_0 ")
-                .append("    JOIN tech_stack ts2_0 ON ts2_0.id = ts1_0.tech_stack_id ")
-                .append("    WHERE ts2_0.name IN (:techStackNames) ")
-                .append("    GROUP BY ts1_0.article_id ")
-                .append("    HAVING COUNT(DISTINCT ts1_0.tech_stack_id) = :techStackCount ")
-                .append(") AS filtered_articles ON a1_0.id = filtered_articles.article_id ")
-                .append("WHERE 1=1 ");
+        StringBuilder whereClause = new StringBuilder();
 
         if (sector != null) {
-            sql.append("AND a1_0.sector = :sector ");
+            whereClause.append("AND a1_0.sector = :sector ");
         }
         if (searchKeyword != null && searchKeyword.hasValue()) {
-            sql.append("AND MATCH(a1_0.title, a1_0.summary, a1_0.content) AGAINST(:searchQuery IN BOOLEAN MODE) ");
+            whereClause.append(
+                    "AND MATCH(a1_0.title, a1_0.summary, a1_0.content) AGAINST(:searchQuery IN BOOLEAN MODE) ");
+        }
+        if (!CollectionUtils.isEmpty(topics)) {
+            for (int i = 0; i < topics.size(); i++) {
+                whereClause.append("AND :topic").append(i).append(" IN (")
+                           .append("SELECT t1_0.topics FROM article_topics t1_0 WHERE a1_0.id = t1_0.article_id")
+                           .append(") ");
+            }
         }
         if (articleCursor != null) {
             if (sortBy == ArticleSortType.CLICKS) {
-                sql.append(
+                whereClause.append(
                         "AND (a1_0.clicks < :cursorClicks OR (a1_0.clicks = :cursorClicks AND a1_0.id < :cursorId)) ");
             } else {
-                sql.append(
+                whereClause.append(
                         "AND (a1_0.created_at < :cursorCreatedAt OR (a1_0.created_at = :cursorCreatedAt AND a1_0.id < :cursorId)) ");
             }
         }
 
-        return sql.toString();
+        return whereClause.toString();
     }
 
     private String buildOrderByClause(ArticleQueryCondition queryCondition) {
         Sector sector = queryCondition.sector();
         ArticleSortType sortBy = queryCondition.sortBy();
 
-        StringBuilder sql = new StringBuilder(100);
+        StringBuilder sql = new StringBuilder();
         sql.append("ORDER BY ");
         if (sector != null) {
             sql.append("a1_0.sector ASC, ");
@@ -325,12 +279,13 @@ public class CustomizedArticleRepositoryImpl implements CustomizedArticleReposit
         return sql.toString();
     }
 
-    private void setCommonTechStackParameters(Query query, ArticleQueryCondition queryCondition) {
+    private void setTechStackParameters(Query query, ArticleQueryCondition queryCondition) {
         SearchKeyword searchKeyword = queryCondition.search();
         Sector sector = queryCondition.sector();
         List<String> techStackNames = queryCondition.techStackNames();
         ArticleSortType sortBy = queryCondition.sortBy();
         Cursor<?> articleCursor = queryCondition.articleCursor();
+        List<Topic> topics = queryCondition.topics();
 
         query.setParameter("techStackNames", techStackNames);
         query.setParameter("techStackCount", techStackNames.size());
@@ -340,6 +295,11 @@ public class CustomizedArticleRepositoryImpl implements CustomizedArticleReposit
         }
         if (searchKeyword != null && searchKeyword.hasValue()) {
             query.setParameter("searchQuery", formatSearchKeyword(searchKeyword));
+        }
+        if (!CollectionUtils.isEmpty(topics)) {
+            for (int i = 0; i < topics.size(); i++) {
+                query.setParameter("topic" + i, topics.get(i).name());
+            }
         }
         if (articleCursor != null) {
             if (sortBy == ArticleSortType.CLICKS) {


### PR DESCRIPTION
# 🎯 이슈 번호

- close #391 

## ✅ 체크 리스트

- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 🏁 작업 내용

쿼리 최적화를 위해 다음과 같은 기준을 적용했습니다.
-  `search` → 있으면 WHERE 절에 조건 추가
    
    ```sql
    and match (title, summary, content) against (? in boolean mode)>? 
    ```
    
- `sort` → 필수 값 → ORDER BY에 조건 추가
    
    ```sql
    order by
        a1_0.clicks desc,
        a1_0.id desc 
    
    order by
        a1_0.createdAt desc,
        a1_0.id desc 
    ```
    
- `limit` → 필수 값 → LMIT에 조건 추가
    
    ```sql
    limit
        ?
    ```
    
- `cursor` → 있으면 WHERE 절에 조건 추가
    
    ```sql
    and (
        a1_0.clicks<? 
        or a1_0.clicks=? 
        and a1_0.id<?
    ) 
    
    and (
          a1_0.created_at<? 
          or a1_0.created_at=? 
          and a1_0.id<?
    ) 
    ```
    
- `sectror` → 있으면 WHERE 절과 ORDER BY 절에 조건 추가
    
    ```sql
    where
        a1_0.sector=? 
    
    order by
        a1_0.sector,
        a1_0.clicks desc,
        a1_0.id desc 
    ```
    
- `techStacks` → FROM 절에 JOIN 서브쿼리 추가
    
    ```sql
    JOIN
    (SELECT
         ts1_0.article_id
     FROM
         article_tech_stack ts1_0
             JOIN
         tech_stack ts2_0 ON ts2_0.id = ts1_0.tech_stack_id
     WHERE
         ts2_0.name in ('java', 'docker')
     GROUP BY
         ts1_0.article_id
     HAVING
         COUNT(DISTINCT ts1_0.tech_stack_id) = 2
    ) AS filtered_articles ON a1_0.id = filtered_articles.article_id
    ```
    
- `topics` -> WHERE 절에 IN 조건 추가
    
    ```sql
    'API_DESIGN' IN (SELECT t1_0.topics FROM article_topics t1_0 WHERE a1_0.id = t1_0.article_id)
      AND 'DATABASE' IN (SELECT t1_0.topics FROM article_topics t1_0 WHERE a1_0.id = t1_0.article_id)
    ```

## 🎸 기타

- QueryDSL로 JOIN 절에 서브쿼리를  포함시킬 수 없어서 해당 케이스에는 네이티브 쿼리를 사용했습니다.
- 선택 기준에 대한 내용은 [노션](https://www.notion.so/2794b522306480468a2ed70a780fe55c?source=copy_link)에 문서화 해뒀습니다.
