### PR TITLE
fix(BE): 엘라스틱 서치 메모리 문제로 인한 자바힙 메모리 고정 설정

### DIFF
--- a/.github/workflows/be-dev-cd.yml
+++ b/.github/workflows/be-dev-cd.yml
@@ -3,8 +3,6 @@ name: BE Dev CD
 on:
   push:
     branches: [ "develop" ]
-  pull_request:
-    branches: [ "develop" ]
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/be-dev-cd.yml
+++ b/.github/workflows/be-dev-cd.yml
@@ -3,6 +3,8 @@ name: BE Dev CD
 on:
   push:
     branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
 
 jobs:
   build-and-push-image:

--- a/backend/compose.dev.yaml
+++ b/backend/compose.dev.yaml
@@ -41,12 +41,12 @@ services:
       timeout: 5s
       retries: 5
 
-  kibana:
-    image: docker.elastic.co/kibana/kibana:9.1.4
-    ports:
-      - "5601:5601"
-    environment:
-      - ELASTICSEARCH_HOSTS=http://elastic:9200
+#  kibana:
+#    image: docker.elastic.co/kibana/kibana:9.1.4
+#    ports:
+#      - "5601:5601"
+#    environment:
+#      - ELASTICSEARCH_HOSTS=http://elastic:9200
 
   app:
     image: ${DOCKERHUB_USERNAME}/moaon-backend:${IMAGE_TAG}

--- a/backend/compose.dev.yaml
+++ b/backend/compose.dev.yaml
@@ -32,6 +32,7 @@ services:
       - discovery.type=single-node
       - xpack.security.enabled=false
       - xpack.security.http.ssl.enabled=false
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
     volumes:
       - es_data:/usr/share/elasticsearch/data
     healthcheck:

--- a/backend/compose.prod.yaml
+++ b/backend/compose.prod.yaml
@@ -9,6 +9,7 @@ services:
       - discovery.type=single-node
       - xpack.security.enabled=false
       - xpack.security.http.ssl.enabled=false
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
     volumes:
       - es_data:/usr/share/elasticsearch/data
     healthcheck:

--- a/backend/compose.prod.yaml
+++ b/backend/compose.prod.yaml
@@ -18,12 +18,12 @@ services:
       timeout: 5s
       retries: 5
 
-  kibana:
-    image: docker.elastic.co/kibana/kibana:9.1.4
-    ports:
-      - "5601:5601"
-    environment:
-      - ELASTICSEARCH_HOSTS=http://elastic:9200
+#  kibana:
+#    image: docker.elastic.co/kibana/kibana:9.1.4
+#    ports:
+#      - "5601:5601"
+#    environment:
+#      - ELASTICSEARCH_HOSTS=http://elastic:9200
 
   app:
     image: ${DOCKERHUB_USERNAME}/moaon-backend:${IMAGE_TAG}


### PR DESCRIPTION
# 🎯 이슈 번호

close #415

## ✅ 체크 리스트

- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 🏁 작업 내용

- 작업한 내용을 간략하게 작성해주세요.
EC2 메모리를 확인한 결과 ES가 33% 키바나가 25% 메모릴 잡아먹고있어

JVM위에서 ES가 돌아가고있는데, 이 메모리 해결을 위해 java heap 메모리 설정을
     ` - ES_JAVA_OPTS=-Xms512m -Xmx512m` 하여 메모리 사용을 줄이고
우선 키바나를 사용하지 않도록 변경하였습니다


## 🎸 기타

- 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
