### PR TITLE
feat(FE): 프론트엔드 배포 캐시 정책 적용 

### DIFF
--- a/frontend/buildspec.yml
+++ b/frontend/buildspec.yml
@@ -27,10 +27,6 @@ phases:
       - aws s3 cp dist/index.html s3://${S3_BUCKET_NAME}/index.html \
         --cache-control "no-cache"
 
-      # 3. CloudFront 캐시 무효화 (index.html)
-      - aws cloudfront create-invalidation \ --distribution-id
-        ${CLOUDFRONT_DISTRIBUTION_ID} \ --paths "/index.html"
-
 artifacts:
   base-directory: frontend/dist
   files:

--- a/frontend/buildspec.yml
+++ b/frontend/buildspec.yml
@@ -17,6 +17,20 @@ phases:
       - pwd
       - ls -al dist
 
+  post_build:
+    commands:
+      # 1. JS/CSS/이미지 → 1년 캐시
+      - aws s3 sync dist/ s3://${S3_BUCKET_NAME} \ --exclude "index.html" \
+        --cache-control "public, max-age=31536000, immutable" \ --delete
+
+      # 2. index.html → no-cache
+      - aws s3 cp dist/index.html s3://${S3_BUCKET_NAME}/index.html \
+        --cache-control "no-cache"
+
+      # 3. CloudFront 캐시 무효화 (index.html)
+      - aws cloudfront create-invalidation \ --distribution-id
+        ${CLOUDFRONT_DISTRIBUTION_ID} \ --paths "/index.html"
+
 artifacts:
   base-directory: frontend/dist
   files:


### PR DESCRIPTION
# 🎯 이슈 번호

close #421 

## ✅ 체크 리스트

- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

<img width="754" height="481" alt="image" src="https://github.com/user-attachments/assets/80c28e20-2b0a-4ee6-ba4e-5e5412a83134" />

### 문제/배경
- 기존 buildspec.yml은 캐시 정책이 없고 CloudFront invalidation도 없음
- 반복 방문 시 페이지 로딩 속도 저하, HTML 업데이트 반영 지연

### 🏁 작업 내용

- buildspec.yml에 post_build 단계 추가
  - JS/CSS/이미지 → 1년 캐시 (immutable)
  - index.html → no-cache
  - CloudFront 캐시 무효화(index.html만)

- S3 버킷 이름과 CloudFront 배포 ID를 환경변수로 관리하도록 수정
  - S3_BUCKET_NAME, CLOUDFRONT_DISTRIBUTION_ID

### 기대 효과
- 정적 자원 캐시 TTL 증가 → 페이지 반복 방문 속도 개선
- index.html 항상 최신화 → 사용자에게 최신 페이지 제공
- CloudFront invalidation 비용 절감 (HTML만 무효화)
