### PR TITLE
fix(BE): 아티클 조회 쿼리 빌드 오류 수정

### DIFF
--- a/backend/src/main/java/moaon/backend/article/repository/CustomizedArticleRepositoryImpl.java
+++ b/backend/src/main/java/moaon/backend/article/repository/CustomizedArticleRepositoryImpl.java
@@ -257,14 +257,16 @@ public class CustomizedArticleRepositoryImpl implements CustomizedArticleReposit
     }
 
     private String buildWhereCursorClause(ArticleQueryCondition queryCondition) {
-        if (queryCondition.articleCursor() == null) {
-            return null;
-        }
+        Cursor<?> cursor = queryCondition.articleCursor();
+        ArticleSortType sortType = queryCondition.sortBy();
 
-        if (queryCondition.sortBy() == ArticleSortType.CLICKS) {
-            return "AND (a1_0.clicks < :cursorClicks OR (a1_0.clicks = :cursorClicks AND a1_0.id < :cursorId)) ";
+        if (cursor != null) {
+            if (sortType == ArticleSortType.CLICKS) {
+                return "AND (a1_0.clicks < :cursorClicks OR (a1_0.clicks = :cursorClicks AND a1_0.id < :cursorId)) ";
+            }
+            return "AND (a1_0.created_at < :cursorCreatedAt OR (a1_0.created_at = :cursorCreatedAt AND a1_0.id < :cursorId)) ";
         }
-        return "AND (a1_0.created_at < :cursorCreatedAt OR (a1_0.created_at = :cursorCreatedAt AND a1_0.id < :cursorId)) ";
+        return "AND 1=1";
     }
 
     private String buildOrderByClause(ArticleQueryCondition queryCondition) {


### PR DESCRIPTION
# 🎯 이슈 번호

- close #428 

## ✅ 체크 리스트

- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 🏁 작업 내용

- 쿼리 개선 과정에서 발생한 오류를 수정했습니다.
- 아티클 조회 + techStack 이 포함됐을 때 -> Native Query 사용 중
  - 이때 cursor가 넘어오지 않을 경우 `buildWhereCursorClause`가 null을 반환하면서 `findWithTechStackFilter`의 `String.join` 에서 NPE가 발생함

## 🎸 기타

- 네이티브쿼리 사용하니까 디버깅 불편함이 느껴짐
- 추후에 쿼리 튜닝하면서 최대한 네이티브 쿼리 안하고 해결할 수 있는 방식으로 리팩터링 해볼게요

