### PR TITLE
refactor(BE): 아티클 조회 쿼리 메모리 기반 조인 쿼리로 성능 최적화

### DIFF
--- a/backend/src/main/java/moaon/backend/article/controller/ArticleController.java
+++ b/backend/src/main/java/moaon/backend/article/controller/ArticleController.java
@@ -77,7 +77,7 @@ public class ArticleController {
                 cursor
         );
 
-        return ResponseEntity.ok(articleService.getPagedArticles2(queryCondition));
+        return ResponseEntity.ok(articleService.getPagedArticles(queryCondition));
     }
 
 

--- a/backend/src/main/java/moaon/backend/article/controller/ArticleController.java
+++ b/backend/src/main/java/moaon/backend/article/controller/ArticleController.java
@@ -57,6 +57,30 @@ public class ArticleController {
         return ResponseEntity.ok(articleService.getPagedArticles(queryCondition));
     }
 
+    @GetMapping("/v2")
+    public ResponseEntity<ArticleResponse> getPagedArticles2(
+            @RequestParam(value = "sort", required = false) String sortType,
+            @RequestParam(value = "techStacks", required = false) List<String> techStacks,
+            @RequestParam(value = "sector", required = false) String sector,
+            @RequestParam(value = "topics", required = false) List<String> topics,
+            @RequestParam(value = "search", required = false) String search,
+            @RequestParam(value = "limit") @Validated @Max(100) int limit,
+            @RequestParam(value = "cursor", required = false) String cursor
+    ) {
+        ArticleQueryCondition queryCondition = ArticleQueryCondition.from(
+                search,
+                sector,
+                topics,
+                techStacks,
+                sortType,
+                limit,
+                cursor
+        );
+
+        return ResponseEntity.ok(articleService.getPagedArticles2(queryCondition));
+    }
+
+
     @PostMapping("/{id}/clicks")
     public ResponseEntity<Void> updateArticleClicks(
             @PathVariable("id") long id,

--- a/backend/src/main/java/moaon/backend/article/controller/ArticleController.java
+++ b/backend/src/main/java/moaon/backend/article/controller/ArticleController.java
@@ -57,30 +57,6 @@ public class ArticleController {
         return ResponseEntity.ok(articleService.getPagedArticles(queryCondition));
     }
 
-    @GetMapping("/v2")
-    public ResponseEntity<ArticleResponse> getPagedArticles2(
-            @RequestParam(value = "sort", required = false) String sortType,
-            @RequestParam(value = "techStacks", required = false) List<String> techStacks,
-            @RequestParam(value = "sector", required = false) String sector,
-            @RequestParam(value = "topics", required = false) List<String> topics,
-            @RequestParam(value = "search", required = false) String search,
-            @RequestParam(value = "limit") @Validated @Max(100) int limit,
-            @RequestParam(value = "cursor", required = false) String cursor
-    ) {
-        ArticleQueryCondition queryCondition = ArticleQueryCondition.from(
-                search,
-                sector,
-                topics,
-                techStacks,
-                sortType,
-                limit,
-                cursor
-        );
-
-        return ResponseEntity.ok(articleService.getPagedArticles(queryCondition));
-    }
-
-
     @PostMapping("/{id}/clicks")
     public ResponseEntity<Void> updateArticleClicks(
             @PathVariable("id") long id,

--- a/backend/src/main/java/moaon/backend/article/dao/ArticleDao.java
+++ b/backend/src/main/java/moaon/backend/article/dao/ArticleDao.java
@@ -55,6 +55,22 @@ public class ArticleDao {
                 .fetch();
     }
 
+    public List<Article> findAllBy(
+            long projectId,
+            Sector sector,
+            SearchKeyword searchKeyword
+    ) {
+        return jpaQueryFactory.
+                selectFrom(article)
+                .where(
+                        article.project.id.eq(projectId),
+                        equalSector(sector),
+                        satisfiesMatchScore(searchKeyword)
+                )
+                .fetch();
+
+    }
+
     public List<Long> findIdsByTechStackNames(List<String> techStackNames) {
         if (CollectionUtils.isEmpty(techStackNames)) {
             return Collections.emptyList();
@@ -144,7 +160,7 @@ public class ArticleDao {
         return article.id.in(articleIds);
     }
 
-    public BooleanExpression equalSector(Sector sector) {
+    private BooleanExpression equalSector(Sector sector) {
         if (sector == null) {
             return null;
         }
@@ -158,7 +174,7 @@ public class ArticleDao {
         return cursor.getCursorExpression();
     }
 
-    public BooleanExpression satisfiesMatchScore(SearchKeyword searchKeyword) {
+    private BooleanExpression satisfiesMatchScore(SearchKeyword searchKeyword) {
         if (searchKeyword == null || !searchKeyword.hasValue()) {
             return null;
         }

--- a/backend/src/main/java/moaon/backend/article/dao/ArticleDao.java
+++ b/backend/src/main/java/moaon/backend/article/dao/ArticleDao.java
@@ -1,0 +1,178 @@
+package moaon.backend.article.dao;
+
+import static moaon.backend.article.domain.QArticle.article;
+import static moaon.backend.techStack.domain.QArticleTechStack.articleTechStack;
+import static moaon.backend.techStack.domain.QTechStack.techStack;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import moaon.backend.article.domain.Article;
+import moaon.backend.article.domain.ArticleSortType;
+import moaon.backend.article.domain.Sector;
+import moaon.backend.article.domain.Topic;
+import moaon.backend.article.dto.ArticleQueryCondition;
+import moaon.backend.article.repository.ArticleFullTextSearchHQLFunction;
+import moaon.backend.global.cursor.Cursor;
+import moaon.backend.global.domain.SearchKeyword;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.CollectionUtils;
+
+@Repository
+@RequiredArgsConstructor
+public class ArticleDao {
+
+    private static final double MINIMUM_MATCH_SCORE = 0.0;
+    private static final int FETCH_EXTRA_FOR_HAS_NEXT = 1;
+    private static final String BLANK = " ";
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private final JdbcTemplate jdbcTemplate;
+
+    public List<Article> findArticles(List<Long> articleIdsBySector, ArticleQueryCondition queryCondition) {
+        return jpaQueryFactory
+                .selectFrom(article)
+                .where(
+                        applyCursor(queryCondition.articleCursor()),
+                        articleIdIn(articleIdsBySector)
+                )
+                .orderBy(toOrderBy(queryCondition.sortBy()))
+                .limit(queryCondition.limit() + FETCH_EXTRA_FOR_HAS_NEXT)
+                .fetch();
+    }
+
+    public List<Long> findArticleIdsByTechStackNames(List<String> techStackNames) {
+        if (CollectionUtils.isEmpty(techStackNames)) {
+            return Collections.emptyList();
+        }
+
+        return jpaQueryFactory
+                .select(articleTechStack.article.id)
+                .from(articleTechStack)
+                .join(articleTechStack.techStack, techStack)
+                .where(techStack.name.in(techStackNames))
+                .groupBy(articleTechStack.article.id)
+                .having(techStack.name.count().eq((long) techStackNames.size()))
+                .fetch();
+    }
+
+    public List<Long> findArticleIdsByTopics(List<Topic> topics) {
+        if (CollectionUtils.isEmpty(topics)) {
+            return Collections.emptyList();
+        }
+
+        String sql = """
+                SELECT
+                    article_id
+                FROM
+                    article_topics
+                WHERE
+                    topics in (:topics)
+                GROUP BY
+                    article_id
+                HAVING
+                    COUNT(article_id) = :topicCount;
+                """;
+        List<String> topicNames = topics.stream()
+                .map(Topic::name)
+                .toList();
+        return jdbcTemplate.queryForList(sql, Long.class, topicNames, topics.size());
+    }
+
+    public List<Long> findArticleIdsBySearchKeyword(SearchKeyword searchKeyword) {
+        if (searchKeyword == null || !searchKeyword.hasValue()) {
+            return Collections.emptyList();
+        }
+
+        return jpaQueryFactory
+                .select(article.id)
+                .from(article)
+                .where(satisfiesMatchScore(searchKeyword))
+                .fetch();
+    }
+
+    public List<Long> findArticleIdsBySector(Sector sector, Set<Long> filteredIds) {
+        if (sector == null && CollectionUtils.isEmpty(filteredIds)) {
+            return Collections.emptyList();
+        }
+
+        return jpaQueryFactory
+                .select(article.id)
+                .from(article)
+                .where(
+                        equalSector(sector),
+                        articleIdIn(filteredIds)
+                )
+                .fetch();
+    }
+
+    public BooleanExpression articleIdIn(Set<Long> articleIds) {
+        if (CollectionUtils.isEmpty(articleIds)) {
+            return null;
+        }
+        return article.id.in(articleIds);
+    }
+
+    public BooleanExpression articleIdIn(List<Long> articleIds) {
+        if (CollectionUtils.isEmpty(articleIds)) {
+            return null;
+        }
+        return article.id.in(articleIds);
+    }
+
+    public BooleanExpression equalSector(Sector sector) {
+        if (sector == null) {
+            return null;
+        }
+        return article.sector.eq(sector);
+    }
+
+    public BooleanExpression satisfiesMatchScore(SearchKeyword searchKeyword) {
+        if (searchKeyword == null || !searchKeyword.hasValue()) {
+            return null;
+        }
+        return Expressions.numberTemplate(
+                        Double.class,
+                        ArticleFullTextSearchHQLFunction.EXPRESSION_TEMPLATE,
+                        formatSearchKeyword(searchKeyword)
+                )
+                .gt(MINIMUM_MATCH_SCORE);
+    }
+
+    public BooleanExpression applyCursor(Cursor<?> cursor) {
+        if (cursor == null) {
+            return null;
+        }
+        return cursor.getCursorExpression();
+    }
+
+    public String formatSearchKeyword(SearchKeyword searchKeyword) {
+        String search = searchKeyword.replaceSpecialCharacters(BLANK);
+        return Arrays.stream(search.split(BLANK))
+                .map(this::applyBooleanModeExpression)
+                .collect(Collectors.joining(BLANK));
+    }
+
+    public String applyBooleanModeExpression(String keyword) {
+        if (keyword.length() == 1) {
+            return String.format("%s*", keyword);
+        }
+        return String.format("+%s*", keyword.toLowerCase());
+    }
+
+    public OrderSpecifier<?>[] toOrderBy(ArticleSortType sortBy) {
+        if (sortBy == ArticleSortType.CLICKS) {
+            return new OrderSpecifier<?>[]{article.clicks.desc(), article.id.desc()};
+        }
+
+        return new OrderSpecifier<?>[]{article.createdAt.desc(), article.id.desc()};
+    }
+}

--- a/backend/src/main/java/moaon/backend/article/domain/Article.java
+++ b/backend/src/main/java/moaon/backend/article/domain/Article.java
@@ -33,7 +33,7 @@ import moaon.backend.techStack.domain.TechStack;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @EqualsAndHashCode(of = "id", callSuper = false)
-@ToString
+@ToString(exclude = {"project", "techStacks"})
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @Table(indexes = {

--- a/backend/src/main/java/moaon/backend/article/domain/Article.java
+++ b/backend/src/main/java/moaon/backend/article/domain/Article.java
@@ -33,7 +33,7 @@ import moaon.backend.techStack.domain.TechStack;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @EqualsAndHashCode(of = "id", callSuper = false)
-@ToString(exclude = {"project", "techStacks"})
+@ToString(exclude = {"project", "techStacks", "topics"})
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @Table(indexes = {

--- a/backend/src/main/java/moaon/backend/article/domain/Articles.java
+++ b/backend/src/main/java/moaon/backend/article/domain/Articles.java
@@ -1,0 +1,39 @@
+package moaon.backend.article.domain;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import moaon.backend.global.cursor.Cursor;
+
+@RequiredArgsConstructor
+@Getter
+@ToString
+public class Articles {
+
+    private final List<Article> articles;
+    private final long totalCount;
+    private final int limit;
+
+    public List<Article> getArticlesToReturn() {
+        if (hasNext()) {
+            return articles.subList(0, limit);
+        }
+
+        return articles;
+    }
+
+    public Cursor<?> getNextCursor(ArticleSortType sortType) {
+        if (hasNext()) {
+            List<Article> articlesToReturn = getArticlesToReturn();
+            Article lastArticle = articlesToReturn.getLast();
+            return sortType.toCursor(lastArticle);
+        }
+
+        return null;
+    }
+
+    public boolean hasNext() {
+        return articles.size() > limit;
+    }
+}

--- a/backend/src/main/java/moaon/backend/article/dto/ArticleQueryCondition.java
+++ b/backend/src/main/java/moaon/backend/article/dto/ArticleQueryCondition.java
@@ -7,6 +7,7 @@ import moaon.backend.article.domain.Sector;
 import moaon.backend.article.domain.Topic;
 import moaon.backend.global.cursor.Cursor;
 import moaon.backend.global.domain.SearchKeyword;
+import org.springframework.util.CollectionUtils;
 
 public record ArticleQueryCondition(
         SearchKeyword search,
@@ -44,5 +45,12 @@ public record ArticleQueryCondition(
                 limit,
                 sortBy.toCursor(cursor)
         );
+    }
+
+    public boolean hasFilter() {
+        return (search != null && search.hasValue())
+                || sector != null
+                || !CollectionUtils.isEmpty(topics)
+                || !CollectionUtils.isEmpty(techStackNames);
     }
 }

--- a/backend/src/main/java/moaon/backend/article/dto/ArticleQueryCondition.java
+++ b/backend/src/main/java/moaon/backend/article/dto/ArticleQueryCondition.java
@@ -13,7 +13,7 @@ public record ArticleQueryCondition(
         Sector sector,
         List<Topic> topics,
         List<String> techStackNames,
-        ArticleSortType sortBy,
+        ArticleSortType sortType,
         int limit,
         Cursor<?> articleCursor
 ) {

--- a/backend/src/main/java/moaon/backend/article/dto/ArticleQueryCondition.java
+++ b/backend/src/main/java/moaon/backend/article/dto/ArticleQueryCondition.java
@@ -15,7 +15,7 @@ public record ArticleQueryCondition(
         List<String> techStackNames,
         ArticleSortType sortType,
         int limit,
-        Cursor<?> articleCursor
+        Cursor<?> cursor
 ) {
 
     public static ArticleQueryCondition from(

--- a/backend/src/main/java/moaon/backend/article/repository/CustomizedArticleRepository.java
+++ b/backend/src/main/java/moaon/backend/article/repository/CustomizedArticleRepository.java
@@ -9,8 +9,6 @@ public interface CustomizedArticleRepository {
 
     List<Article> findWithSearchConditions(ArticleQueryCondition queryCondition);
 
-    List<Article> findWithSearchConditions2(ArticleQueryCondition queryCondition);
-
     long countWithSearchCondition(ArticleQueryCondition queryCondition);
 
     List<Article> findAllByProjectIdAndCondition(long id, ProjectArticleQueryCondition condition);

--- a/backend/src/main/java/moaon/backend/article/repository/CustomizedArticleRepository.java
+++ b/backend/src/main/java/moaon/backend/article/repository/CustomizedArticleRepository.java
@@ -9,6 +9,8 @@ public interface CustomizedArticleRepository {
 
     List<Article> findWithSearchConditions(ArticleQueryCondition queryCondition);
 
+    List<Article> findWithSearchConditions2(ArticleQueryCondition queryCondition);
+
     long countWithSearchCondition(ArticleQueryCondition queryCondition);
 
     List<Article> findAllByProjectIdAndCondition(long id, ProjectArticleQueryCondition condition);

--- a/backend/src/main/java/moaon/backend/article/repository/CustomizedArticleRepository.java
+++ b/backend/src/main/java/moaon/backend/article/repository/CustomizedArticleRepository.java
@@ -2,14 +2,13 @@ package moaon.backend.article.repository;
 
 import java.util.List;
 import moaon.backend.article.domain.Article;
+import moaon.backend.article.domain.Articles;
 import moaon.backend.article.dto.ArticleQueryCondition;
 import moaon.backend.project.dto.ProjectArticleQueryCondition;
 
 public interface CustomizedArticleRepository {
 
-    List<Article> findWithSearchConditions(ArticleQueryCondition queryCondition);
-
-    long countWithSearchCondition(ArticleQueryCondition queryCondition);
+    Articles findWithSearchConditions(ArticleQueryCondition queryCondition);
 
     List<Article> findAllByProjectIdAndCondition(long id, ProjectArticleQueryCondition condition);
 }

--- a/backend/src/main/java/moaon/backend/article/repository/CustomizedArticleRepositoryImpl.java
+++ b/backend/src/main/java/moaon/backend/article/repository/CustomizedArticleRepositoryImpl.java
@@ -2,168 +2,46 @@ package moaon.backend.article.repository;
 
 import static moaon.backend.article.domain.QArticle.article;
 import static moaon.backend.techStack.domain.QArticleTechStack.articleTechStack;
-import static moaon.backend.techStack.domain.QTechStack.techStack;
 
-import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import moaon.backend.article.dao.ArticleDao;
 import moaon.backend.article.domain.Article;
-import moaon.backend.article.domain.ArticleSortType;
 import moaon.backend.article.domain.Sector;
-import moaon.backend.article.domain.Topic;
 import moaon.backend.article.dto.ArticleQueryCondition;
-import moaon.backend.global.cursor.Cursor;
 import moaon.backend.global.domain.SearchKeyword;
 import moaon.backend.project.dto.ProjectArticleQueryCondition;
 import org.springframework.stereotype.Repository;
-import org.springframework.util.CollectionUtils;
 
 @Slf4j
 @Repository
 @RequiredArgsConstructor
 public class CustomizedArticleRepositoryImpl implements CustomizedArticleRepository {
 
-    private static final int FETCH_EXTRA_FOR_HAS_NEXT = 1;
-    private static final double MINIMUM_MATCH_SCORE = 0.0;
-    private static final String BLANK = " ";
-
     private final JPAQueryFactory jpaQueryFactory;
-    private final EntityManager entityManager;
+    private final ArticleDao articleDao;
 
     @Override
     public List<Article> findWithSearchConditions(ArticleQueryCondition queryCondition) {
-        List<String> techStackNames = queryCondition.techStackNames();
-        SearchKeyword searchKeyword = queryCondition.search();
-        Sector sector = queryCondition.sector();
-        ArticleSortType sortBy = queryCondition.sortBy();
-        Cursor<?> articleCursor = queryCondition.articleCursor();
-        List<Topic> topics = queryCondition.topics();
-        int limit = queryCondition.limit();
-
-        List<Long> articleIdsByTechStacks = findArticleIdsByTechStackNames(techStackNames);
-        List<Long> articleIdsByTopics = findArticleIdsByTopics(topics);
-        List<Long> articleIdsBySearch = findArticleIdsBySearchKeyword(searchKeyword);
-        Set<Long> filteredIds = intersectionIds(
+        List<Long> articleIdsByTechStacks = articleDao.findArticleIdsByTechStackNames(queryCondition.techStackNames());
+        List<Long> articleIdsByTopics = articleDao.findArticleIdsByTopics(queryCondition.topics());
+        List<Long> articleIdsBySearch = articleDao.findArticleIdsBySearchKeyword(queryCondition.search());
+        Set<Long> filteredIds = intersect(
                 articleIdsByTechStacks,
                 articleIdsByTopics,
                 articleIdsBySearch
         );
-        List<Long> articleIdsBySector = findArticleIdsBySector(sector, filteredIds);
+        List<Long> articleIdsBySector = articleDao.findArticleIdsBySector(queryCondition.sector(), filteredIds);
 
-        return jpaQueryFactory
-                .selectFrom(article)
-                .where(
-                        applyCursor(articleCursor),
-                        articleIdIn(articleIdsBySector)
-                )
-                .orderBy(toOrderByWithSector(sortBy, sector))
-                .limit(limit + FETCH_EXTRA_FOR_HAS_NEXT)
-                .fetch();
-    }
-
-    private Set<Long> intersectionIds(
-            List<Long> ids1,
-            List<Long> ids2,
-            List<Long> ids3
-    ) {
-        List<List<Long>> allLists = new ArrayList<>(List.of(ids1, ids2, ids3));
-
-        List<Long> smallestList = Collections.min(allLists, Comparator.comparingInt(List::size));
-        Set<Long> intersection = new HashSet<>(smallestList);
-        allLists.remove(smallestList);
-        for (List<Long> currentList : allLists) {
-            intersection.retainAll(new HashSet<>(currentList));
-        }
-
-        return intersection;
-    }
-
-    private List<Long> findArticleIdsByTechStackNames(List<String> techStackNames) {
-        if (CollectionUtils.isEmpty(techStackNames)) {
-            return null;
-        }
-
-        return jpaQueryFactory
-                .select(articleTechStack.article.id)
-                .from(articleTechStack)
-                .join(articleTechStack.techStack, techStack)
-                .where(techStack.name.in(techStackNames))
-                .groupBy(articleTechStack.article.id)
-                .having(techStack.name.count().eq((long) techStackNames.size()))
-                .fetch();
-    }
-
-    private List<Long> findArticleIdsByTopics(List<Topic> topics) { // articleTopics 엔티티가 없음. NativeQuery로?
-        if (CollectionUtils.isEmpty(topics)) {
-            return null;
-        }
-
-        String sql = """
-                SELECT
-                    article_id
-                FROM
-                    article_topics
-                WHERE
-                    topics in (:topics)
-                GROUP BY
-                    article_id
-                HAVING
-                    COUNT(article_id) = :topicCount;
-                """;
-        Query query = entityManager.createNativeQuery(sql, Long.class);
-        query.setParameter("topics", topics.stream().map(Topic::name).toList());
-        query.setParameter("topicCount", topics.size());
-
-        return query.getResultList();
-    }
-
-    private List<Long> findArticleIdsBySearchKeyword(SearchKeyword searchKeyword) {
-        if (searchKeyword == null || !searchKeyword.hasValue()) {
-            return null;
-        }
-        return jpaQueryFactory
-                .select(article.id)
-                .from(article)
-                .where(satisfiesMatchScore(searchKeyword))
-                .fetch();
-    }
-
-    private List<Long> findArticleIdsBySector(Sector sector, Set<Long> filteredIds) {
-        return jpaQueryFactory
-                .select(article.id)
-                .from(article)
-                .where(
-                        equalSector(sector),
-                        articleIdIn(filteredIds)
-                )
-                .fetch();
-    }
-
-    private BooleanExpression articleIdIn(Set<Long> articleIds) {
-        if (CollectionUtils.isEmpty(articleIds)) {
-            return null;
-        }
-        return article.id.in(articleIds);
-    }
-
-    private BooleanExpression articleIdIn(List<Long> articleIds) {
-        if (CollectionUtils.isEmpty(articleIds)) {
-            return null;
-        }
-        return article.id.in(articleIds);
+        return articleDao.findArticles(articleIdsBySector, queryCondition);
     }
 
     @Override
@@ -199,77 +77,26 @@ public class CustomizedArticleRepositoryImpl implements CustomizedArticleReposit
                 .leftJoin(article.techStacks, articleTechStack)
                 .where(
                         article.project.id.eq(id),
-                        equalSector(sector),
-                        satisfiesMatchScore(searchKeyword)
+                        articleDao.equalSector(sector),
+                        articleDao.satisfiesMatchScore(searchKeyword)
                 )
                 .fetch();
     }
 
-    private BooleanExpression equalSector(Sector sector) {
-        if (sector == null) {
-            return null;
-        }
-        return article.sector.eq(sector);
-    }
-
-    private BooleanExpression satisfiesMatchScore(SearchKeyword searchKeyword) {
-        if (searchKeyword == null || !searchKeyword.hasValue()) {
-            return null;
-        }
-        return Expressions.numberTemplate(
-                        Double.class,
-                        ArticleFullTextSearchHQLFunction.EXPRESSION_TEMPLATE,
-                        formatSearchKeyword(searchKeyword)
-                )
-                .gt(MINIMUM_MATCH_SCORE);
-    }
-
-    private BooleanExpression applyCursor(Cursor<?> cursor) {
-        if (cursor == null) {
-            return null;
-        }
-        return cursor.getCursorExpression();
-    }
-
-    private String formatSearchKeyword(SearchKeyword searchKeyword) {
-        String search = searchKeyword.replaceSpecialCharacters(BLANK);
-        return Arrays.stream(search.split(BLANK))
-                .map(this::applyBooleanModeExpression)
-                .collect(Collectors.joining(BLANK));
-    }
-
-    private String applyBooleanModeExpression(String keyword) {
-        if (keyword.length() == 1) {
-            return String.format("%s*", keyword);
-        }
-        return String.format("+%s*", keyword.toLowerCase());
-    }
-
-    private OrderSpecifier<?>[] toOrderByWithSector(ArticleSortType sortBy, Sector sector) {
-        if (sector == null) {
-            return toOrderBy(sortBy);
+    @SafeVarargs
+    private Set<Long> intersect(List<Long>... idLists) {
+        if (idLists == null || idLists.length == 0) {
+            return Collections.emptySet();
         }
 
-        if (sortBy == ArticleSortType.CLICKS) {
-            return new OrderSpecifier<?>[]{
-                    article.sector.asc(),
-                    article.clicks.desc(),
-                    article.id.desc()
-            };
-        }
-
-        return new OrderSpecifier<?>[]{
-                article.sector.asc(),
-                article.createdAt.desc(),
-                article.id.desc()
-        };
-    }
-
-    private OrderSpecifier<?>[] toOrderBy(ArticleSortType sortBy) {
-        if (sortBy == ArticleSortType.CLICKS) {
-            return new OrderSpecifier<?>[]{article.clicks.desc(), article.id.desc()};
-        }
-
-        return new OrderSpecifier<?>[]{article.createdAt.desc(), article.id.desc()};
+        return Arrays.stream(idLists)
+                .filter(Objects::nonNull)
+                .map(HashSet::new)
+                .sorted(Comparator.comparingInt(Set::size))
+                .reduce((first, second) -> {
+                    first.retainAll(second);
+                    return first;
+                })
+                .orElse(new HashSet<>());
     }
 }

--- a/backend/src/main/java/moaon/backend/article/repository/CustomizedArticleRepositoryImpl.java
+++ b/backend/src/main/java/moaon/backend/article/repository/CustomizedArticleRepositoryImpl.java
@@ -34,11 +34,12 @@ public class CustomizedArticleRepositoryImpl implements CustomizedArticleReposit
                 articleIdsTechStacksAndTopics,
                 articleDao.findIdsBySearchKeyword(queryCondition.search())
         );
+        log.info("{}", articleIdsByTechStacksAndTopicsSearch);
         Set<Long> filteringIds = articleDao.findIdsBySector(
                 queryCondition.sector(),
                 articleIdsByTechStacksAndTopicsSearch
         );
-
+        log.info("{}", filteringIds);
         if (queryCondition.hasFilter() && filteringIds.isEmpty()) {
             return new Articles(Collections.emptyList(), 0, queryCondition.limit());
         }

--- a/backend/src/main/java/moaon/backend/article/service/ArticleService.java
+++ b/backend/src/main/java/moaon/backend/article/service/ArticleService.java
@@ -36,8 +36,7 @@ public class ArticleService {
         boolean hasNext = articles.hasNext();
 
         Cursor<?> nextCursor = articles.getNextCursor(queryCondition.sortType());
-        return ArticleResponse.from(articlesToReturn, totalCount, hasNext,
-                nextCursor == null ? null : nextCursor.getNextCursor());
+        return ArticleResponse.from(articlesToReturn, totalCount, hasNext, getNextCursor(nextCursor));
     }
 
     public ProjectArticleResponse getByProjectId(long id, ProjectArticleQueryCondition condition) {
@@ -61,5 +60,12 @@ public class ArticleService {
         Article article = articleRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.ARTICLE_NOT_FOUND));
         article.addClickCount();
+    }
+
+    private String getNextCursor(final Cursor<?> nextCursor) {
+        if (nextCursor == null) {
+            return null;
+        }
+        return nextCursor.getNextCursor();
     }
 }

--- a/backend/src/main/java/moaon/backend/article/service/ArticleService.java
+++ b/backend/src/main/java/moaon/backend/article/service/ArticleService.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import moaon.backend.article.domain.Article;
+import moaon.backend.article.domain.Articles;
 import moaon.backend.article.domain.Sector;
 import moaon.backend.article.dto.ArticleQueryCondition;
 import moaon.backend.article.dto.ArticleResponse;
@@ -28,23 +29,15 @@ public class ArticleService {
     private final ProjectRepository projectRepository;
 
     public ArticleResponse getPagedArticles(ArticleQueryCondition queryCondition) {
-        List<Article> articles = articleRepository.findWithSearchConditions(queryCondition);
-        long totalCount = articleRepository.countWithSearchCondition(queryCondition);
+        Articles articles = articleRepository.findWithSearchConditions(queryCondition);
 
-        if (articles.size() > queryCondition.limit()) {
-            List<Article> articlesToReturn = articles.subList(0, queryCondition.limit());
-            Article lastArticle = articlesToReturn.getLast();
+        List<Article> articlesToReturn = articles.getArticlesToReturn();
+        long totalCount = articles.getTotalCount();
+        boolean hasNext = articles.hasNext();
 
-            Cursor<?> articleCursor = queryCondition.sortBy().toCursor(lastArticle);
-
-            return ArticleResponse.from(
-                    articlesToReturn,
-                    totalCount,
-                    true,
-                    articleCursor.getNextCursor());
-        }
-
-        return ArticleResponse.from(articles, totalCount, false, null);
+        Cursor<?> nextCursor = articles.getNextCursor(queryCondition.sortType());
+        return ArticleResponse.from(articlesToReturn, totalCount, hasNext,
+                nextCursor == null ? null : nextCursor.getNextCursor());
     }
 
     public ProjectArticleResponse getByProjectId(long id, ProjectArticleQueryCondition condition) {

--- a/backend/src/main/java/moaon/backend/article/service/ArticleService.java
+++ b/backend/src/main/java/moaon/backend/article/service/ArticleService.java
@@ -47,26 +47,6 @@ public class ArticleService {
         return ArticleResponse.from(articles, totalCount, false, null);
     }
 
-    public ArticleResponse getPagedArticles2(ArticleQueryCondition queryCondition) {
-        List<Article> articles = articleRepository.findWithSearchConditions(queryCondition);
-        long totalCount = articleRepository.countWithSearchCondition(queryCondition);
-
-        if (articles.size() > queryCondition.limit()) {
-            List<Article> articlesToReturn = articles.subList(0, queryCondition.limit());
-            Article lastArticle = articlesToReturn.getLast();
-
-            Cursor<?> articleCursor = queryCondition.sortBy().toCursor(lastArticle);
-
-            return ArticleResponse.from(
-                    articlesToReturn,
-                    totalCount,
-                    true,
-                    articleCursor.getNextCursor());
-        }
-
-        return ArticleResponse.from(articles, totalCount, false, null);
-    }
-
     public ProjectArticleResponse getByProjectId(long id, ProjectArticleQueryCondition condition) {
         projectRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.PROJECT_NOT_FOUND));

--- a/backend/src/main/java/moaon/backend/article/service/ArticleService.java
+++ b/backend/src/main/java/moaon/backend/article/service/ArticleService.java
@@ -47,6 +47,26 @@ public class ArticleService {
         return ArticleResponse.from(articles, totalCount, false, null);
     }
 
+    public ArticleResponse getPagedArticles2(ArticleQueryCondition queryCondition) {
+        List<Article> articles = articleRepository.findWithSearchConditions(queryCondition);
+        long totalCount = articleRepository.countWithSearchCondition(queryCondition);
+
+        if (articles.size() > queryCondition.limit()) {
+            List<Article> articlesToReturn = articles.subList(0, queryCondition.limit());
+            Article lastArticle = articlesToReturn.getLast();
+
+            Cursor<?> articleCursor = queryCondition.sortBy().toCursor(lastArticle);
+
+            return ArticleResponse.from(
+                    articlesToReturn,
+                    totalCount,
+                    true,
+                    articleCursor.getNextCursor());
+        }
+
+        return ArticleResponse.from(articles, totalCount, false, null);
+    }
+
     public ProjectArticleResponse getByProjectId(long id, ProjectArticleQueryCondition condition) {
         projectRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.PROJECT_NOT_FOUND));

--- a/backend/src/test/java/moaon/backend/article/repository/ArticleRepositorySearchTest.java
+++ b/backend/src/test/java/moaon/backend/article/repository/ArticleRepositorySearchTest.java
@@ -56,9 +56,10 @@ public class ArticleRepositorySearchTest {
         );
 
         // when
-        List<Article> aboutWebpack = repository.findWithSearchConditions(aboutSearchKeyword("webpack"));
-        List<Article> aboutDisk = repository.findWithSearchConditions(aboutSearchKeyword("디스크"));
-        List<Article> aboutRunner = repository.findWithSearchConditions(aboutSearchKeyword("runner offline"));
+        List<Article> aboutWebpack = repository.findWithSearchConditions(aboutSearchKeyword("webpack")).getArticles();
+        List<Article> aboutDisk = repository.findWithSearchConditions(aboutSearchKeyword("디스크")).getArticles();
+        List<Article> aboutRunner = repository.findWithSearchConditions(aboutSearchKeyword("runner offline"))
+                .getArticles();
 
         // then
         assertAll(

--- a/backend/src/test/java/moaon/backend/article/repository/ArticleRepositorySearchTest.java
+++ b/backend/src/test/java/moaon/backend/article/repository/ArticleRepositorySearchTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import java.util.List;
 import moaon.backend.article.dao.ArticleDao;
 import moaon.backend.article.domain.Article;
+import moaon.backend.article.domain.ArticleSortType;
 import moaon.backend.article.domain.Sector;
 import moaon.backend.article.dto.ArticleQueryCondition;
 import moaon.backend.fixture.ArticleFixtureBuilder;
@@ -121,7 +122,7 @@ public class ArticleRepositorySearchTest {
     }
 
     private ArticleQueryCondition aboutSearchKeyword(String keyword) {
-        return new ArticleQueryConditionBuilder()
+        return new ArticleQueryConditionBuilder(10, ArticleSortType.CREATED_AT)
                 .search(keyword)
                 .build();
     }

--- a/backend/src/test/java/moaon/backend/article/repository/ArticleRepositorySearchTest.java
+++ b/backend/src/test/java/moaon/backend/article/repository/ArticleRepositorySearchTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.List;
+import moaon.backend.article.dao.ArticleDao;
 import moaon.backend.article.domain.Article;
 import moaon.backend.article.domain.Sector;
 import moaon.backend.article.dto.ArticleQueryCondition;
@@ -22,7 +23,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 
 @SpringBootTest
-@Import(RepositoryHelper.class)
+@Import({RepositoryHelper.class, ArticleDao.class})
 public class ArticleRepositorySearchTest {
 
     @Autowired

--- a/backend/src/test/java/moaon/backend/article/repository/ArticleRepositoryTest.java
+++ b/backend/src/test/java/moaon/backend/article/repository/ArticleRepositoryTest.java
@@ -2,6 +2,7 @@ package moaon.backend.article.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import moaon.backend.article.dao.ArticleDao;
 import moaon.backend.article.domain.Article;
 import moaon.backend.article.domain.Sector;
 import moaon.backend.fixture.ArticleFixtureBuilder;
@@ -16,7 +17,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest
-@Import({RepositoryHelper.class, QueryDslConfig.class})
+@Import({RepositoryHelper.class, QueryDslConfig.class, ArticleDao.class})
 class ArticleRepositoryTest {
 
     @Autowired

--- a/backend/src/test/java/moaon/backend/article/repository/CustomizedArticleRepositoryImplTest.java
+++ b/backend/src/test/java/moaon/backend/article/repository/CustomizedArticleRepositoryImplTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import moaon.backend.article.dao.ArticleDao;
 import moaon.backend.article.domain.Article;
 import moaon.backend.article.domain.ArticleSortType;
 import moaon.backend.article.domain.Sector;
@@ -27,7 +28,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest
-@Import({RepositoryHelper.class, QueryDslConfig.class})
+@Import({RepositoryHelper.class, QueryDslConfig.class, ArticleDao.class})
 class CustomizedArticleRepositoryImplTest {
 
     @Autowired

--- a/backend/src/test/java/moaon/backend/article/repository/CustomizedArticleRepositoryImplTest.java
+++ b/backend/src/test/java/moaon/backend/article/repository/CustomizedArticleRepositoryImplTest.java
@@ -1,13 +1,16 @@
 package moaon.backend.article.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import moaon.backend.article.dao.ArticleDao;
 import moaon.backend.article.domain.Article;
 import moaon.backend.article.domain.ArticleSortType;
+import moaon.backend.article.domain.Articles;
 import moaon.backend.article.domain.Sector;
+import moaon.backend.article.domain.Topic;
 import moaon.backend.article.dto.ArticleQueryCondition;
 import moaon.backend.fixture.ArticleFixtureBuilder;
 import moaon.backend.fixture.ArticleQueryConditionBuilder;
@@ -50,7 +53,6 @@ class CustomizedArticleRepositoryImplTest {
         Article articleWithCategory = repositoryHelper.save(
                 new ArticleFixtureBuilder()
                         .sector(filterdSector)
-                        .createdAt(LocalDateTime.of(2024, 7, 30, 0, 0))
                         .build()
         );
 
@@ -60,11 +62,8 @@ class CustomizedArticleRepositoryImplTest {
                         .build()
         );
 
-        ArticleQueryCondition queryCondition = new ArticleQueryConditionBuilder()
+        ArticleQueryCondition queryCondition = new ArticleQueryConditionBuilder(10, ArticleSortType.CREATED_AT)
                 .sector(filterdSector)
-                .sortBy(ArticleSortType.CREATED_AT)
-                .limit(10)
-                .cursor(new CreatedAtArticleCursor(LocalDateTime.of(2024, 7, 31, 10, 0), 1L))
                 .build();
 
         // when
@@ -83,22 +82,18 @@ class CustomizedArticleRepositoryImplTest {
 
         Article articleWithTechStacks = repositoryHelper.save(
                 new ArticleFixtureBuilder()
-                        .techStacks(List.of(techStack1, techStack2))
-                        .createdAt(LocalDateTime.of(2024, 7, 30, 0, 0))
+                        .techStacks(techStack1, techStack2)
                         .build()
         );
 
         repositoryHelper.save(
                 new ArticleFixtureBuilder()
-                        .techStacks(List.of(techStack2))
+                        .techStacks(techStack2)
                         .build()
         );
 
-        ArticleQueryCondition queryCondition = new ArticleQueryConditionBuilder()
-                .techStackNames(List.of(techStack1.getName(), techStack2.getName()))
-                .sortBy(ArticleSortType.CREATED_AT)
-                .limit(10)
-                .cursor(new CreatedAtArticleCursor(LocalDateTime.of(2024, 7, 31, 10, 0), 1L))
+        ArticleQueryCondition queryCondition = new ArticleQueryConditionBuilder(10, ArticleSortType.CREATED_AT)
+                .techStackNames(techStack1.getName(), techStack2.getName())
                 .build();
 
         // when
@@ -108,43 +103,125 @@ class CustomizedArticleRepositoryImplTest {
         assertThat(articles).containsOnlyOnce(articleWithTechStacks);
     }
 
-    @DisplayName("직군, 기술스택 필터를 이용하여 아티클을 조회한다.")
+    @DisplayName("주제 필터를 이용하여 아티클을 조회한다.")
     @Test
-    void findWithTechStackAndCategoryFilter() {
+    void findWithTopicsFilter() {
         // given
-        TechStack techStack1 = Fixture.anyTechStack();
-        TechStack techStack2 = Fixture.anyTechStack();
+        Topic topic = Topic.TECHNOLOGY_ADOPTION;
 
-        Sector sector = Fixture.randomSector();
-
-        Article articleWithTechStacksAndCategory = repositoryHelper.save(
+        Article articleWithTopic = repositoryHelper.save(
                 new ArticleFixtureBuilder()
-                        .techStacks(List.of(techStack1, techStack2))
-                        .sector(sector)
-                        .createdAt(LocalDateTime.of(2024, 7, 30, 0, 0))
+                        .topics(topic)
                         .build()
         );
-
         repositoryHelper.save(
                 new ArticleFixtureBuilder()
-                        .techStacks(List.of(techStack2))
-                        .sector(sector)
+                        .topics(Topic.PERFORMANCE_OPTIMIZATION)
                         .build()
         );
 
-        ArticleQueryCondition queryCondition = new ArticleQueryConditionBuilder()
-                .sector(sector)
-                .techStackNames(List.of(techStack1.getName(), techStack2.getName()))
-                .sortBy(ArticleSortType.CREATED_AT)
-                .limit(10)
-                .cursor(new CreatedAtArticleCursor(LocalDateTime.of(2024, 7, 31, 10, 0), 1L))
+        ArticleQueryCondition queryCondition = new ArticleQueryConditionBuilder(10, ArticleSortType.CREATED_AT)
+                .topics(topic)
                 .build();
 
         // when
         List<Article> articles = customizedArticleRepository.findWithSearchConditions(queryCondition).getArticles();
 
         // then
-        assertThat(articles).containsOnlyOnce(articleWithTechStacksAndCategory);
+        assertThat(articles).containsOnlyOnce(articleWithTopic);
+    }
+
+    @DisplayName("직군, 주제, 기술스택 필터를 이용하여 아티클을 조회한다.")
+    @Test
+    void findWithTechStackAndCategoryFilter() {
+        // given
+        TechStack techStack1 = Fixture.anyTechStack();
+        TechStack techStack2 = Fixture.anyTechStack();
+        Topic topic = Topic.TECHNOLOGY_ADOPTION;
+        Sector sector = Fixture.randomSector();
+
+        Article articleWithTechStacksAndCategoryAndTopic = repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .techStacks(techStack1, techStack2)
+                        .sector(sector)
+                        .topics(topic)
+                        .build()
+        );
+        repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .techStacks(techStack1, techStack2)
+                        .build()
+        );
+        repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .sector(sector)
+                        .build()
+        );
+        repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .topics(topic)
+                        .build()
+        );
+        repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .build()
+        );
+
+        ArticleQueryCondition queryCondition = new ArticleQueryConditionBuilder(10, ArticleSortType.CREATED_AT)
+                .sector(sector)
+                .topics(topic)
+                .techStackNames(List.of(techStack1.getName(), techStack2.getName()))
+                .build();
+
+        // when
+        List<Article> articles = customizedArticleRepository.findWithSearchConditions(queryCondition).getArticles();
+
+        // then
+        assertThat(articles).containsOnlyOnce(articleWithTechStacksAndCategoryAndTopic);
+    }
+
+    @DisplayName("필터 조건이 없으면 모든 아티클을 반환한다.")
+    @Test
+    void findWithNoFilter() {
+        // given
+        Article article1 = repositoryHelper.save(new ArticleFixtureBuilder().build());
+        Article article2 = repositoryHelper.save(new ArticleFixtureBuilder().build());
+        Article article3 = repositoryHelper.save(new ArticleFixtureBuilder().build());
+
+        ArticleQueryCondition queryCondition = new ArticleQueryConditionBuilder(10, ArticleSortType.CREATED_AT).build();
+
+        // when
+        List<Article> articles = customizedArticleRepository.findWithSearchConditions(queryCondition).getArticles();
+
+        // then
+        assertThat(articles).containsExactlyInAnyOrder(article1, article2, article3);
+    }
+
+    @DisplayName("필터 조건에 해당하는 결과가 없으면 빈 결과값을 반환한다.")
+    @Test
+    void findWithEmptyResult() {
+        // given
+        Sector existingSector = Sector.BE;
+        Sector nonExistingSector = Sector.FE;
+
+        repositoryHelper.save(
+                new ArticleFixtureBuilder()
+                        .sector(existingSector)
+                        .build()
+        );
+
+        ArticleQueryCondition queryCondition = new ArticleQueryConditionBuilder(10, ArticleSortType.CREATED_AT)
+                .sector(nonExistingSector)
+                .build();
+
+        // when
+        Articles articles = customizedArticleRepository.findWithSearchConditions(queryCondition);
+
+        // then
+        assertAll(
+                () -> assertThat(articles.getTotalCount()).isZero(),
+                () -> assertThat(articles.getArticles()).isEmpty()
+        );
     }
 
     @DisplayName("아티클을 생성일자를 기준으로 정렬한다.")
@@ -179,14 +256,12 @@ class CustomizedArticleRepositoryImplTest {
                         .build()
         );
 
-        ArticleQueryCondition queryCondition1 = new ArticleQueryConditionBuilder()
-                .sortBy(ArticleSortType.CREATED_AT)
-                .limit(10)
+        ArticleQueryCondition queryCondition = new ArticleQueryConditionBuilder(10, ArticleSortType.CREATED_AT)
                 .cursor(new CreatedAtArticleCursor(LocalDateTime.of(2024, 7, 31, 10, 0), 1L))
                 .build();
 
         // when
-        List<Article> articles = customizedArticleRepository.findWithSearchConditions(queryCondition1).getArticles();
+        List<Article> articles = customizedArticleRepository.findWithSearchConditions(queryCondition).getArticles();
 
         // then
         assertThat(articles).containsExactly(tomorrowArticle, todayArticle, yesterdayArticle);
@@ -226,9 +301,7 @@ class CustomizedArticleRepositoryImplTest {
                         .build()
         );
 
-        ArticleQueryCondition queryCondition = new ArticleQueryConditionBuilder()
-                .sortBy(ArticleSortType.CLICKS)
-                .limit(10)
+        ArticleQueryCondition queryCondition = new ArticleQueryConditionBuilder(10, ArticleSortType.CLICKS)
                 .cursor(new ClickArticleCursor(4, 4L))
                 .build();
 
@@ -243,106 +316,49 @@ class CustomizedArticleRepositoryImplTest {
     @Test
     void findArticlesForLimitPlusOne() {
         // given
-        repositoryHelper.save(
-                new ArticleFixtureBuilder()
-                        .clicks(3)
-                        .build()
-        );
+        repositoryHelper.save(new ArticleFixtureBuilder().build());
+        repositoryHelper.save(new ArticleFixtureBuilder().build());
+        repositoryHelper.save(new ArticleFixtureBuilder().build());
+        repositoryHelper.save(new ArticleFixtureBuilder().build());
+        repositoryHelper.save(new ArticleFixtureBuilder().build());
+        repositoryHelper.save(new ArticleFixtureBuilder().build());
 
-        repositoryHelper.save(
-                new ArticleFixtureBuilder()
-                        .clicks(3)
-                        .build()
-        );
-
-        repositoryHelper.save(
-                new ArticleFixtureBuilder()
-                        .clicks(3)
-                        .build()
-        );
-
-        repositoryHelper.save(
-                new ArticleFixtureBuilder()
-                        .clicks(3)
-                        .build()
-        );
-
-        repositoryHelper.save(
-                new ArticleFixtureBuilder()
-                        .clicks(3)
-                        .build()
-        );
-
-        repositoryHelper.save(
-                new ArticleFixtureBuilder()
-                        .clicks(3)
-                        .build()
-        );
-
-        ArticleQueryCondition queryCondition = new ArticleQueryConditionBuilder()
-                .sortBy(ArticleSortType.CLICKS)
-                .limit(4)
-                .cursor(new ClickArticleCursor(4, 99999999L))
-                .build();
+        ArticleQueryCondition queryCondition = new ArticleQueryConditionBuilder(4, ArticleSortType.CLICKS).build();
 
         // when
-        List<Article> articles = customizedArticleRepository.findWithSearchConditions(queryCondition).getArticles();
+        Articles articles = customizedArticleRepository.findWithSearchConditions(queryCondition);
 
         // then
-        assertThat(articles).hasSize(5);
+        assertAll(
+                () -> assertThat(articles.getLimit()).isEqualTo(4),
+                () -> assertThat(articles.getArticles()).hasSize(5),
+                () -> assertThat(articles.hasNext()).isTrue()
+        );
     }
 
     @DisplayName("마지막 페이지 도달하면 limit 개수 이하로 가져온다.")
     @Test
     void findArticlesForUnderLimit() {
         // given
-        repositoryHelper.save(
-                new ArticleFixtureBuilder()
-                        .clicks(3)
-                        .build()
-        );
+        repositoryHelper.save(new ArticleFixtureBuilder().build());
+        repositoryHelper.save(new ArticleFixtureBuilder().build());
+        repositoryHelper.save(new ArticleFixtureBuilder().build());
+        repositoryHelper.save(new ArticleFixtureBuilder().build());
+        repositoryHelper.save(new ArticleFixtureBuilder().build());
+        repositoryHelper.save(new ArticleFixtureBuilder().build());
 
-        repositoryHelper.save(
-                new ArticleFixtureBuilder()
-                        .clicks(3)
-                        .build()
-        );
-
-        repositoryHelper.save(
-                new ArticleFixtureBuilder()
-                        .clicks(3)
-                        .build()
-        );
-
-        repositoryHelper.save(
-                new ArticleFixtureBuilder()
-                        .clicks(3)
-                        .build()
-        );
-
-        repositoryHelper.save(
-                new ArticleFixtureBuilder()
-                        .clicks(3)
-                        .build()
-        );
-
-        repositoryHelper.save(
-                new ArticleFixtureBuilder()
-                        .clicks(3)
-                        .build()
-        );
-
-        ArticleQueryCondition queryCondition = new ArticleQueryConditionBuilder()
-                .sortBy(ArticleSortType.CLICKS)
-                .limit(9)
-                .cursor(new ClickArticleCursor(4, 999999L))
-                .build();
+        ArticleQueryCondition queryCondition = new ArticleQueryConditionBuilder(9, ArticleSortType.CLICKS).build();
 
         // when
-        List<Article> articles = customizedArticleRepository.findWithSearchConditions(queryCondition).getArticles();
+        Articles articles = customizedArticleRepository.findWithSearchConditions(queryCondition);
 
         // then
-        assertThat(articles).hasSize(6);
+        assertAll(
+                () -> assertThat(articles.getLimit()).isEqualTo(9),
+                () -> assertThat(articles.getArticles()).hasSize(6),
+                () -> assertThat(articles.getTotalCount()).isEqualTo(6),
+                () -> assertThat(articles.hasNext()).isFalse()
+        );
     }
 
     @DisplayName("cursor 가 없는 경우 초기 데이터를 가져온다.")
@@ -367,9 +383,7 @@ class CustomizedArticleRepositoryImplTest {
                         .build()
         );
 
-        ArticleQueryCondition queryCondition = new ArticleQueryConditionBuilder()
-                .sortBy(ArticleSortType.CLICKS)
-                .limit(9)
+        ArticleQueryCondition queryCondition = new ArticleQueryConditionBuilder(9, ArticleSortType.CLICKS)
                 .cursor(new CreatedAtArticleCursor(LocalDateTime.now(), 1L))
                 .build();
 
@@ -400,8 +414,8 @@ class CustomizedArticleRepositoryImplTest {
                         .build()
         );
 
-        ArticleQueryCondition queryCondition = new ArticleQueryConditionBuilder()
-                .techStackNames(List.of(techStack1.getName(), techStack2.getName()))
+        ArticleQueryCondition queryCondition = new ArticleQueryConditionBuilder(10, ArticleSortType.CREATED_AT)
+                .techStackNames(techStack1.getName(), techStack2.getName())
                 .build();
 
         // when

--- a/backend/src/test/java/moaon/backend/article/repository/CustomizedArticleRepositoryImplTest.java
+++ b/backend/src/test/java/moaon/backend/article/repository/CustomizedArticleRepositoryImplTest.java
@@ -68,7 +68,7 @@ class CustomizedArticleRepositoryImplTest {
                 .build();
 
         // when
-        List<Article> articles = customizedArticleRepository.findWithSearchConditions(queryCondition);
+        List<Article> articles = customizedArticleRepository.findWithSearchConditions(queryCondition).getArticles();
 
         // then
         assertThat(articles).containsOnlyOnce(articleWithCategory);
@@ -102,7 +102,7 @@ class CustomizedArticleRepositoryImplTest {
                 .build();
 
         // when
-        List<Article> articles = customizedArticleRepository.findWithSearchConditions(queryCondition);
+        List<Article> articles = customizedArticleRepository.findWithSearchConditions(queryCondition).getArticles();
 
         // then
         assertThat(articles).containsOnlyOnce(articleWithTechStacks);
@@ -141,7 +141,7 @@ class CustomizedArticleRepositoryImplTest {
                 .build();
 
         // when
-        List<Article> articles = customizedArticleRepository.findWithSearchConditions(queryCondition);
+        List<Article> articles = customizedArticleRepository.findWithSearchConditions(queryCondition).getArticles();
 
         // then
         assertThat(articles).containsOnlyOnce(articleWithTechStacksAndCategory);
@@ -186,7 +186,7 @@ class CustomizedArticleRepositoryImplTest {
                 .build();
 
         // when
-        List<Article> articles = customizedArticleRepository.findWithSearchConditions(queryCondition1);
+        List<Article> articles = customizedArticleRepository.findWithSearchConditions(queryCondition1).getArticles();
 
         // then
         assertThat(articles).containsExactly(tomorrowArticle, todayArticle, yesterdayArticle);
@@ -233,7 +233,7 @@ class CustomizedArticleRepositoryImplTest {
                 .build();
 
         // when
-        List<Article> articles = customizedArticleRepositoryImpl.findWithSearchConditions(queryCondition);
+        List<Article> articles = customizedArticleRepositoryImpl.findWithSearchConditions(queryCondition).getArticles();
 
         // then
         assertThat(articles).containsExactly(highClicks, middleClicks, lowClicks);
@@ -286,7 +286,7 @@ class CustomizedArticleRepositoryImplTest {
                 .build();
 
         // when
-        List<Article> articles = customizedArticleRepository.findWithSearchConditions(queryCondition);
+        List<Article> articles = customizedArticleRepository.findWithSearchConditions(queryCondition).getArticles();
 
         // then
         assertThat(articles).hasSize(5);
@@ -339,7 +339,7 @@ class CustomizedArticleRepositoryImplTest {
                 .build();
 
         // when
-        List<Article> articles = customizedArticleRepository.findWithSearchConditions(queryCondition);
+        List<Article> articles = customizedArticleRepository.findWithSearchConditions(queryCondition).getArticles();
 
         // then
         assertThat(articles).hasSize(6);
@@ -374,7 +374,7 @@ class CustomizedArticleRepositoryImplTest {
                 .build();
 
         // when
-        List<Article> articles = customizedArticleRepository.findWithSearchConditions(queryCondition);
+        List<Article> articles = customizedArticleRepository.findWithSearchConditions(queryCondition).getArticles();
 
         // then
         assertThat(articles).containsExactly(articleWithId1, articleWithId2, articleWithId3);
@@ -405,7 +405,7 @@ class CustomizedArticleRepositoryImplTest {
                 .build();
 
         // when
-        long count = customizedArticleRepository.countWithSearchCondition(queryCondition);
+        long count = customizedArticleRepository.findWithSearchConditions(queryCondition).getTotalCount();
 
         // then
         assertThat(count).isEqualTo(2);

--- a/backend/src/test/java/moaon/backend/article/service/ArticleServiceTest.java
+++ b/backend/src/test/java/moaon/backend/article/service/ArticleServiceTest.java
@@ -66,9 +66,7 @@ class ArticleServiceTest {
         Mockito.when(articleRepository.findWithSearchConditions(Mockito.any()))
                 .thenReturn(new Articles(articles, 5L, 2));
 
-        ArticleQueryCondition articleQueryCondition = new ArticleQueryConditionBuilder()
-                .sortBy(ArticleSortType.CREATED_AT)
-                .limit(2)
+        ArticleQueryCondition articleQueryCondition = new ArticleQueryConditionBuilder(2, ArticleSortType.CREATED_AT)
                 .build();
 
         Cursor<?> articleCursor = articleQueryCondition.sortType().toCursor(article2);
@@ -110,9 +108,7 @@ class ArticleServiceTest {
         Mockito.when(articleRepository.findWithSearchConditions(Mockito.any()))
                 .thenReturn(new Articles(articles, 5L, 3));
 
-        ArticleQueryCondition articleQueryCondition = new ArticleQueryConditionBuilder()
-                .sortBy(ArticleSortType.CREATED_AT)
-                .limit(3)
+        ArticleQueryCondition articleQueryCondition = new ArticleQueryConditionBuilder(3, ArticleSortType.CREATED_AT)
                 .build();
 
         ArticleContent articleContent1 = ArticleContent.from(article1);

--- a/backend/src/test/java/moaon/backend/article/service/ArticleServiceTest.java
+++ b/backend/src/test/java/moaon/backend/article/service/ArticleServiceTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Optional;
 import moaon.backend.article.domain.Article;
 import moaon.backend.article.domain.ArticleSortType;
+import moaon.backend.article.domain.Articles;
 import moaon.backend.article.dto.ArticleContent;
 import moaon.backend.article.dto.ArticleQueryCondition;
 import moaon.backend.article.dto.ArticleResponse;
@@ -63,16 +64,14 @@ class ArticleServiceTest {
         List<Article> articles = List.of(article1, article2, article3);
 
         Mockito.when(articleRepository.findWithSearchConditions(Mockito.any()))
-                .thenReturn(articles);
+                .thenReturn(new Articles(articles, 5L, 2));
 
         ArticleQueryCondition articleQueryCondition = new ArticleQueryConditionBuilder()
                 .sortBy(ArticleSortType.CREATED_AT)
                 .limit(2)
                 .build();
 
-        Cursor<?> articleCursor = articleQueryCondition.sortBy().toCursor(article2);
-
-        Mockito.when(articleRepository.countWithSearchCondition(articleQueryCondition)).thenReturn(5L);
+        Cursor<?> articleCursor = articleQueryCondition.sortType().toCursor(article2);
 
         ArticleContent articleContent1 = ArticleContent.from(article1);
         ArticleContent articleContent2 = ArticleContent.from(article2);
@@ -109,14 +108,12 @@ class ArticleServiceTest {
         List<Article> articles = List.of(article1, article2, article3);
 
         Mockito.when(articleRepository.findWithSearchConditions(Mockito.any()))
-                .thenReturn(articles);
+                .thenReturn(new Articles(articles, 5L, 3));
 
         ArticleQueryCondition articleQueryCondition = new ArticleQueryConditionBuilder()
                 .sortBy(ArticleSortType.CREATED_AT)
                 .limit(3)
                 .build();
-
-        Mockito.when(articleRepository.countWithSearchCondition(articleQueryCondition)).thenReturn(5L);
 
         ArticleContent articleContent1 = ArticleContent.from(article1);
         ArticleContent articleContent2 = ArticleContent.from(article2);

--- a/backend/src/test/java/moaon/backend/fixture/ArticleFixtureBuilder.java
+++ b/backend/src/test/java/moaon/backend/fixture/ArticleFixtureBuilder.java
@@ -67,6 +67,11 @@ public class ArticleFixtureBuilder {
         return this;
     }
 
+    public ArticleFixtureBuilder techStacks(TechStack... techStacks) {
+        this.techStacks = Arrays.asList(techStacks);
+        return this;
+    }
+
     public ArticleFixtureBuilder sector(Sector sector) {
         this.sector = sector;
         return this;
@@ -106,11 +111,11 @@ public class ArticleFixtureBuilder {
                 .topics(this.topics)
                 .techStacks(new ArrayList<>())
                 .build();
-        
+
         for (TechStack techStack : techStacks) {
             article.addTechStack(techStack);
         }
-        
+
         return article;
     }
 }

--- a/backend/src/test/java/moaon/backend/fixture/ArticleQueryConditionBuilder.java
+++ b/backend/src/test/java/moaon/backend/fixture/ArticleQueryConditionBuilder.java
@@ -19,13 +19,13 @@ public class ArticleQueryConditionBuilder {
     private int limit;
     private Cursor<?> articleCursor;
 
-    public ArticleQueryConditionBuilder() {
+    public ArticleQueryConditionBuilder(int limit, ArticleSortType sortType) {
         this.search = new SearchKeyword(null);
         this.sector = null;
         this.topics = null;
         this.techStackNames = null;
-        this.sortBy = null;
-        this.limit = 50;
+        this.sortBy = sortType;
+        this.limit = limit;
         this.articleCursor = null;
     }
 
@@ -46,6 +46,11 @@ public class ArticleQueryConditionBuilder {
 
     public ArticleQueryConditionBuilder techStackNames(List<String> techStackNames) {
         this.techStackNames = techStackNames;
+        return this;
+    }
+
+    public ArticleQueryConditionBuilder techStackNames(String... techStackNames) {
+        this.techStackNames = Arrays.asList(techStackNames);
         return this;
     }
 


### PR DESCRIPTION
# 🎯 이슈 번호

- close #431

## ✅ 체크 리스트

- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 🏁 작업 내용

### 아티클 쿼리 개선 (`/articles`, `/projets/id/articles`)

- 메모리 기반 조인을 활용하는 방식으로 조회 속도 계선했습니다.
- 검색 기능을 제외하고, 대부분의 쿼리 파라미터 경우의 수에 대해 1초 미만의 시간으로 API 응답이 가능합니다. (로컬, 100만개 기준)
- PR 작성하다가 `sector` 조건만 걸었을 때 엄청 느린걸 발견했습니다.. **일단 PR 올려놓고 이 부분 개선**할게요 리뷰 먼저 부탁드립니다!
- **[노션](https://www.notion.so/2-27d4b5223064802f999cfd263b845965?source=copy_link)에 개선 과정 정리해뒀습니다.**
- 프로젝트 상세 페이지 아티클 조회 쿼리도 간단하게 개선했습니다.

### DAO 계층 & Articles 일급 컬렉션 추가

- 말론/포포 PR 참고해서 레포지터리 계층에서 **DAO 계층을 분리**했습니다.
- 말론/포포 PR 참고해서 **Articles 일급 컬렉션**에 서비스에서 처리했던 로직들 + totalCount 저장 책임을 위임했습니다.

### 테스트 추가 및 리팩터링

- `CustomizedArticleRepositoryImpl`에 **Topics 필터링 관련 테스트**가 없어서 **추가**했습니다.
- `CustomizedArticleRepositoryImpl`에 `totalCount`가 0인 경우와 전체 아티클 크기인 경우를 추가했습니다.
- `ArticleQueryConditionBuilder`의 생성자를 수정했습니다. `limit`와 `SortType`을 필수로 입력하도록 수정했습니다.

## 🎸 기타

- 완성된 쿼리들이 사용하는 **인덱스**에 대해서는 곧 정리해서 다시 올리겠습니다.
- `Articles` 일급 컬렉션 위치에 대해 이야기하고 싶습니다. 
  - **`domain` vs `repository`** 
  - 이 친구가 가지는 로직은 '도메인 로직'에 해당하지 않을까요..?
- **`Repository` vs `DAO`**
  - 두 개념의 차이에 대해서 좀 더 이야기해보고 팀 전체의 이해를 정리하고 싶습니다. 저는 지금의 구조를 토대로 이해해 봤을 때, 아래처럼 이해를 했는데 다른 분들 의견도 궁금합니다.
  - **`Repository`**: 도메인 객체를 조건에 맞게 가져오는 계층. 구현 방식(QueryDSL, Spring Data JPA 등)은 관심 영역이 아님.
  - **`DAO`**: DB에 접근하기 위한 계층. 구체적인 구현 방식이 표현됨.
- 리팩터링을 하다가 Cursor랑 es 부분 리팩터링을 추가로 하고싶었는데 PR이 너무 길어질까봐 하지 않았습니다. 시간 되면 따로 이슈 파서 작업해볼게요.