### PR TITLE
refactor(BE): 프로젝트 상세 페이지에서 아티클 검색 로직 개선

### DIFF
--- a/backend/src/main/java/moaon/backend/article/dto/ArticleESQuery.java
+++ b/backend/src/main/java/moaon/backend/article/dto/ArticleESQuery.java
@@ -2,12 +2,14 @@ package moaon.backend.article.dto;
 
 import java.util.List;
 import java.util.Objects;
+import lombok.Builder;
 import moaon.backend.article.domain.ArticleSortType;
 import moaon.backend.article.domain.Sector;
 import moaon.backend.article.domain.Topic;
 import moaon.backend.global.cursor.ESCursor;
 import moaon.backend.global.domain.SearchKeyword;
 
+@Builder
 public record ArticleESQuery(
         SearchKeyword search,
         Sector sector,

--- a/backend/src/main/java/moaon/backend/article/repository/es/ESArticleQueryBuilder.java
+++ b/backend/src/main/java/moaon/backend/article/repository/es/ESArticleQueryBuilder.java
@@ -1,9 +1,14 @@
 package moaon.backend.article.repository.es;
 
+import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.MultiMatchQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermsQuery;
+import jakarta.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
 import moaon.backend.article.domain.ArticleSortType;
 import moaon.backend.article.domain.Sector;
 import moaon.backend.article.domain.Topic;
@@ -16,9 +21,6 @@ import org.springframework.data.domain.Sort.Order;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.client.elc.NativeQueryBuilder;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public class ESArticleQueryBuilder {
 
     private final List<Query> musts = new ArrayList<>();
@@ -26,6 +28,13 @@ public class ESArticleQueryBuilder {
     private Pageable pageable;
     private Sort sort;
     private List<Object> searchAfter;
+
+    public ESArticleQueryBuilder withIds(List<Long> ids) {
+        if (ids != null && !ids.isEmpty()) {
+            filters.add(createIdsQuery(ids));
+        }
+        return this;
+    }
 
     public ESArticleQueryBuilder withTextSearch(SearchKeyword searchKeyword) {
         if (searchKeyword != null && searchKeyword.hasValue()) {
@@ -69,8 +78,9 @@ public class ESArticleQueryBuilder {
         return this;
     }
 
-    public ESArticleQueryBuilder withPagination(int limit, ESCursor cursor) {
-        if (cursor.isEmpty()) {
+    public ESArticleQueryBuilder withPagination(int limit, @Nullable ESCursor cursor) {
+        if (cursor == null || cursor.isEmpty()) {
+            limit = Math.max(limit, 1);
             this.pageable = PageRequest.of(0, limit);
             return this;
         }
@@ -99,6 +109,14 @@ public class ESArticleQueryBuilder {
         }
 
         return builder.build();
+    }
+
+    private Query createIdsQuery(List<Long> ids) {
+        List<FieldValue> values = ids.stream().map(FieldValue::of).toList();
+        return TermsQuery.of(t -> t
+                .field("id")
+                .terms(f -> f.value(values))
+        )._toQuery();
     }
 
     private Query createTextMatchQuery(SearchKeyword searchKeyword) {

--- a/backend/src/main/java/moaon/backend/article/service/ArticleService.java
+++ b/backend/src/main/java/moaon/backend/article/service/ArticleService.java
@@ -1,7 +1,6 @@
 package moaon.backend.article.service;
 
 import java.time.LocalDateTime;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -13,6 +12,7 @@ import moaon.backend.article.domain.Articles;
 import moaon.backend.article.domain.Sector;
 import moaon.backend.article.domain.Topic;
 import moaon.backend.article.dto.ArticleCreateRequest;
+import moaon.backend.article.dto.ArticleESQuery;
 import moaon.backend.article.dto.ArticleQueryCondition;
 import moaon.backend.article.dto.ArticleResponse;
 import moaon.backend.article.repository.ArticleContentRepository;
@@ -52,19 +52,35 @@ public class ArticleService {
     }
 
     public ProjectArticleResponse getByProjectId(long id, ProjectArticleQueryCondition condition) {
-        projectRepository.findById(id)
+        Project project = projectRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.PROJECT_NOT_FOUND));
 
-        List<Article> articles = articleRepository.findAllByProjectIdAndCondition(id, condition);
-        Map<Sector, Long> articleCountBySector = Arrays.stream(Sector.values())
-                .collect(
-                        Collectors.toMap(
-                                sector -> sector,
-                                sector -> articleRepository.countByProjectIdAndSector(id, sector)
-                        )
-                );
+        List<Article> allArticlesInProject = project.getArticles();
+        List<Long> retrievedIds = retrieveInGivenArticles(allArticlesInProject, condition);
+        List<Article> filteredArticles = allArticlesInProject.stream().filter(a -> retrievedIds.contains(a.getId()))
+                .toList();
 
-        return ProjectArticleResponse.of(articles, articleCountBySector);
+        Map<Sector, Long> articleCountBySector = allArticlesInProject.stream()
+                .collect(Collectors.groupingBy(Article::getSector, Collectors.counting()));
+        for (Sector sector : Sector.values()) {
+            articleCountBySector.computeIfAbsent(sector, k -> 0L);
+        }
+        return ProjectArticleResponse.of(filteredArticles, articleCountBySector);
+    }
+
+    private List<Long> retrieveInGivenArticles(List<Article> allArticlesInProject,
+                                               ProjectArticleQueryCondition condition) {
+        ArticleESQuery esQuery = ArticleESQuery.builder()
+                .search(condition.search())
+                .sector(condition.sector())
+                .limit(999)
+                .build();
+
+        List<Long> allArticleIds = allArticlesInProject.stream().map(Article::getId).toList();
+        return articleDocumentRepository.searchInIds(allArticleIds, esQuery)
+                .stream()
+                .map(ArticleDocument::getId)
+                .toList();
     }
 
     @Transactional

--- a/backend/src/test/java/moaon/backend/api/project/ProjectApiTest.java
+++ b/backend/src/test/java/moaon/backend/api/project/ProjectApiTest.java
@@ -15,9 +15,12 @@ import io.restassured.response.ValidatableResponse;
 import java.util.List;
 import moaon.backend.api.BaseApiTest;
 import moaon.backend.article.domain.Article;
+import moaon.backend.article.domain.ArticleDocument;
 import moaon.backend.article.domain.Sector;
 import moaon.backend.article.dto.ArticleDetailResponse;
+import moaon.backend.article.dto.ArticleESQuery;
 import moaon.backend.article.dto.ArticleSectorCount;
+import moaon.backend.article.repository.es.ArticleDocumentRepository;
 import moaon.backend.fixture.ArticleFixtureBuilder;
 import moaon.backend.fixture.Fixture;
 import moaon.backend.fixture.ProjectFixtureBuilder;
@@ -57,6 +60,9 @@ public class ProjectApiTest extends BaseApiTest {
 
     @Autowired
     private MemberRepository memberRepository;
+
+    @MockitoBean
+    private ArticleDocumentRepository articleDocumentRepository;
 
     @MockitoBean
     private OAuthService oAuthService;
@@ -290,6 +296,12 @@ public class ProjectApiTest extends BaseApiTest {
                         .title(unfilteredSearch)
                         .build()
         );
+
+        Mockito.doReturn(List.of(
+                new ArticleDocument(targetProjectArticle1),
+                new ArticleDocument(targetProjectArticle2),
+                new ArticleDocument(targetProjectArticle3))
+        ).when(articleDocumentRepository).searchInIds(Mockito.anyList(), Mockito.any(ArticleESQuery.class));
 
         // when
         ProjectArticleResponse actualResponse = RestAssured.given(documentationSpecification).log().all()


### PR DESCRIPTION
# 🎯 이슈 번호

close #510 

## ✅ 체크 리스트

- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 🏁 작업 내용

- 작업한 내용을 간략하게 작성해주세요.

로직을 다음과 같이 변경했습니다.
1. `project.getArticles()`의 아이디들을 ES 필터조건에 추가
2. 다른 필터 조건과 결합하여 ES에서 검색 수행
3. 검색된 아티클에 대해 `project.getArticles()`로부터 원본 반환 및 섹터별 카운트 계산

## 🎸 기타

- 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
