### PR TITLE
fix(BE): 프로젝트 상세페이지 아티클 검색을 alias로 검색하도록 변경

### DIFF
--- a/backend/src/main/java/moaon/backend/article/repository/es/ArticleDocumentRepository.java
+++ b/backend/src/main/java/moaon/backend/article/repository/es/ArticleDocumentRepository.java
@@ -49,7 +49,7 @@ public class ArticleDocumentRepository {
                 .withPagination(condition.limit(), condition.cursor())
                 .build();
 
-        SearchHits<ArticleDocument> searchHits = ops.search(esArticleQuery, ArticleDocument.class);
+        SearchHits<ArticleDocument> searchHits = ops.search(esArticleQuery, ArticleDocument.class, ARTICLE_ALIAS);
         return searchHits.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();


### PR DESCRIPTION
# 🎯 이슈 번호

close #510 

## ✅ 체크 리스트

- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 🏁 작업 내용

- 작업한 내용을 간략하게 작성해주세요.

`ops.search(esArticleQuery, ArticleDocument.class)`를
`ops.search(esArticleQuery, ArticleDocument.class, ARTICLE_ALIAS)`로 변경
-> "articles_idx"가 아닌 "articles"로 검색


## 🎸 기타

- 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
