### PR TITLE
fix(BE): 토큰이 없는 경우 isLoggedIn false 반환

### DIFF
--- a/backend/src/main/java/moaon/backend/member/controller/MemberController.java
+++ b/backend/src/main/java/moaon/backend/member/controller/MemberController.java
@@ -21,19 +21,10 @@ public class MemberController {
     ) {
         if (token != null && oAuthService.isValidToken(token)) {
             Member member = oAuthService.getUserByToken(token);
-            return ResponseEntity.ok(responseWithMember(member));
+            return ResponseEntity.ok(LoginStatusResponse.withMember(member));
         }
 
-        return ResponseEntity.ok(new LoginStatusResponse(false, null, null, null));
-    }
-
-    private LoginStatusResponse responseWithMember(Member member) {
-        return new LoginStatusResponse(
-                true,
-                member.getId(),
-                member.getName(),
-                member.getEmail()
-        );
+        return ResponseEntity.ok(LoginStatusResponse.notLoggedIn());
     }
 }
 

--- a/backend/src/main/java/moaon/backend/member/dto/LoginStatusResponse.java
+++ b/backend/src/main/java/moaon/backend/member/dto/LoginStatusResponse.java
@@ -1,9 +1,24 @@
 package moaon.backend.member.dto;
 
+import moaon.backend.member.domain.Member;
+
 public record LoginStatusResponse(
         boolean isLoggedIn,
         Long id,
         String name,
         String email
 ) {
+
+    public static LoginStatusResponse withMember(Member member) {
+        return new LoginStatusResponse(
+                true,
+                member.getId(),
+                member.getName(),
+                member.getEmail()
+        );
+    }
+
+    public static LoginStatusResponse notLoggedIn() {
+        return new LoginStatusResponse(false, null, null, null);
+    }
 }


### PR DESCRIPTION
# 🎯 이슈 번호

close #498 

## ✅ 체크 리스트

- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 🏁 작업 내용

- 작업한 내용을 간략하게 작성해주세요.

토큰이 없는 상태로 `GET /auth/me`를 요청했을 때 NPE로 500에러가 반환되었는데, isLoggedIn = false를 반환하도록 변경했습니다.

## 🎸 기타

- 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
