### PR TITLE
fix(FE): auth 쿼리에서 throwOnError 옵션 제거 및 getAuth API 경로 수정하여 에러 처리

### DIFF
--- a/frontend/src/apis/login/auth.queries.ts
+++ b/frontend/src/apis/login/auth.queries.ts
@@ -7,7 +7,6 @@ export const authQueries = {
     queryOptions({
       queryKey: ["auth"],
       queryFn: () => getAuth(token),
-      throwOnError: true,
       retry: 0,
     }),
   logout: () =>

--- a/frontend/src/apis/login/getAuth.ts
+++ b/frontend/src/apis/login/getAuth.ts
@@ -2,17 +2,21 @@ import { httpClient } from "../HttpClient";
 import type { Auth } from "./auth.type";
 
 const getAuth = async (token?: string): Promise<Auth> => {
-  if (token) {
-    httpClient.setApiKey(token);
+  try {
+    if (token) {
+      httpClient.setApiKey(token);
+    }
+
+    const response = await httpClient.get(`/auth/me`);
+
+    if (!response.ok) {
+      throw new Error("Failed to fetch auth");
+    }
+
+    return response.json();
+  } catch (error) {
+    return { isLoggedIn: false, id: null, name: null, email: null };
   }
-
-  const response = await httpClient.get(`/auth/me`);
-
-  if (!response.ok) {
-    throw new Error("Failed to fetch auth");
-  }
-
-  return response.json();
 };
 
 export default getAuth;


### PR DESCRIPTION
# 🎯 이슈 번호

close #590 

## ✅ 체크 리스트

- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 🏁 작업 내용

- 작업한 내용을 간략하게 작성해주세요.
main 브랜치에 배포할 때 생기는 오류를 처리했습니다.
auth 쿼리에서 throwOnError 옵션 제거 및 getAuth API 경로 수정하여 에러 처리
