### PR TITLE
refactor(BE): 메모리 성능 약간 최적화

### DIFF
--- a/backend/src/main/java/moaon/backend/project/dao/ProjectDao.java
+++ b/backend/src/main/java/moaon/backend/project/dao/ProjectDao.java
@@ -10,6 +10,7 @@ import static moaon.backend.techStack.domain.QTechStack.techStack;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.SimpleExpression;
 import com.querydsl.core.types.dsl.Wildcard;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.Arrays;
@@ -25,6 +26,7 @@ import moaon.backend.project.domain.Project;
 import moaon.backend.project.domain.ProjectCategory;
 import moaon.backend.project.domain.ProjectSortType;
 import moaon.backend.project.dto.ProjectQueryCondition;
+import moaon.backend.project.repository.FilteringIds;
 import moaon.backend.project.repository.ProjectFullTextSearchHQLFunction;
 import moaon.backend.techStack.domain.ProjectTechStack;
 import org.springframework.stereotype.Repository;
@@ -78,40 +80,49 @@ public class ProjectDao {
                 .fetch();
     }
 
-    public Set<Long> findProjectIdsByTechStacks(List<String> techStacks) {
+    public Set<Long> findProjectIdsByTechStacks(FilteringIds filteringIds, List<String> techStacks) {
         if (CollectionUtils.isEmpty(techStacks)) {
             return new HashSet<>();
         }
 
         return new HashSet<>(jpaQueryFactory.select(projectTechStack.project.id)
                 .from(projectTechStack)
-                .where(projectTechStack.techStack.name.in(techStacks))
+                .where(
+                        projectTechStack.techStack.name.in(techStacks),
+                        projectIdInFilteringIds(filteringIds, projectTechStack.project.id)
+                )
                 .groupBy(projectTechStack.project.id)
                 .having(projectTechStack.techStack.name.count().eq((long) techStacks.size()))
                 .fetch());
     }
 
-    public Set<Long> findProjectIdsByCategories(List<String> categories) {
+    public Set<Long> findProjectIdsByCategories(FilteringIds filteringIds, List<String> categories) {
         if (CollectionUtils.isEmpty(categories)) {
             return new HashSet<>();
         }
 
         return new HashSet<>(jpaQueryFactory.select(projectCategory.project.id)
                 .from(projectCategory)
-                .where(projectCategory.category.name.in(categories))
+                .where(
+                        projectCategory.category.name.in(categories),
+                        projectIdInFilteringIds(filteringIds, projectCategory.project.id)
+                )
                 .groupBy(projectCategory.project.id)
                 .having(projectCategory.category.name.count().eq((long) categories.size()))
                 .fetch());
     }
 
-    public Set<Long> findProjectIdsBySearchKeyword(SearchKeyword searchKeyword) {
+    public Set<Long> findProjectIdsBySearchKeyword(FilteringIds filteringIds, SearchKeyword searchKeyword) {
         if (searchKeyword == null || !searchKeyword.hasValue()) {
             return new HashSet<>();
         }
 
         return new HashSet<>(jpaQueryFactory.select(project.id)
                 .from(project)
-                .where(satisfiesMatchScore(searchKeyword))
+                .where(
+                        satisfiesMatchScore(searchKeyword),
+                        projectIdInFilteringIds(filteringIds, project.id)
+                )
                 .fetch());
     }
 
@@ -120,6 +131,18 @@ public class ProjectDao {
                 .from(project)
                 .fetchOne()).orElse(0L);
     }
+
+    private BooleanExpression projectIdInFilteringIds(
+            FilteringIds filteringIds,
+            SimpleExpression<Long> projectIdExpression
+    ) {
+        if (filteringIds.isHasResult()) {
+            return projectIdExpression.in(filteringIds.getIds());
+        }
+
+        return null;
+    }
+
 
     private BooleanExpression idsInCondition(Set<Long> projectIdsByFilter) {
         if (CollectionUtils.isEmpty(projectIdsByFilter)) {

--- a/backend/src/main/java/moaon/backend/project/repository/CustomizedProjectRepositoryImpl.java
+++ b/backend/src/main/java/moaon/backend/project/repository/CustomizedProjectRepositoryImpl.java
@@ -62,7 +62,7 @@ public class CustomizedProjectRepositoryImpl implements CustomizedProjectReposit
             return filteringIds;
         }
 
-        Set<Long> projectIdsByTechStacks = projectDao.findProjectIdsByTechStacks(techStack);
+        Set<Long> projectIdsByTechStacks = projectDao.findProjectIdsByTechStacks(filteringIds, techStack);
         return filteringIds.addFilterResult(projectIdsByTechStacks);
     }
 
@@ -71,7 +71,7 @@ public class CustomizedProjectRepositoryImpl implements CustomizedProjectReposit
             return filteringIds;
         }
 
-        Set<Long> projectIdsByCategories = projectDao.findProjectIdsByCategories(categories);
+        Set<Long> projectIdsByCategories = projectDao.findProjectIdsByCategories(filteringIds, categories);
         return filteringIds.addFilterResult(projectIdsByCategories);
     }
 
@@ -80,7 +80,7 @@ public class CustomizedProjectRepositoryImpl implements CustomizedProjectReposit
             return filteringIds;
         }
 
-        Set<Long> projectIdsBySearchKeyword = projectDao.findProjectIdsBySearchKeyword(keyword);
+        Set<Long> projectIdsBySearchKeyword = projectDao.findProjectIdsBySearchKeyword(filteringIds, keyword);
         return filteringIds.addFilterResult(projectIdsBySearchKeyword);
     }
 


### PR DESCRIPTION
# 🎯 이슈 번호

- close #611 

## ✅ 체크 리스트

- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 🏁 작업 내용

- 작업한 내용을 간략하게 작성해주세요.

기존 방식에서는 **techStack 조건으로 매칭된 project_id와 category 조건으로 매칭된 project_id를 모두 메모리에 적재**한 뒤, 애플리케이션 단에서 교집합 처리했습니다. 이 경우, 제 로컬 목데이터 기준으로 약 25,000개의 project_id가 메모리에 올라갔습니다 (`tech_stack='java'` 14,000개 + `category='web'` 11,596개).

새로운 방식에서는 DB에서 조회할 때, techStack 조건으로 필터된 ID 목록을 기준으로 category 조건을 바로 적용**합니다. 즉, techStack으로 좁혀진 ID만 대상으로 category 교집합을 수행합니다. 이 방식에서는 약 15,000(`tech_stack='java'` 14,000개 + `category='web' && id in (14,000개) 1,100개`)개의 project_id만 메모리에 올라가며, 기존 대비 약 만 건 정도 메모리를 절약할 수 있습니다.

우려되는 점은, **대규모 IN 절에서 랜덤 I/O 부담이 존재할 수 있을 것 같네요.

허나, 지난번 GC로 인한 CPU 부하를 고려하면, 어느 정도는 DB에서 처리하도록 하여 메모리 부담을 줄이는 타협점을 찾는 것이 필요할 것 같습니다. 이 방식이 괜찮다면, article도 수정하면 좋을 것 같아요.

궁금하신 분들은 같이 성능 테스트 해보면 좋을 것 같습니다~

자유롭게 의견주시죠~

실행 계획 전/후도 비교해드릴게요 (로컬 환경에서는 api 시간 차이는 크게 없습니다. 애초에 100ms 정도로 끊던 api 입니다. TPS 를 봐야할 것 같아요)

전
```
-> Filter: (`count(c1_0.``name``)` = 2)  (actual time=14.3..17.4 rows=668 loops=1)
    -> Table scan on <temporary>  (actual time=14.3..16.5 rows=22432 loops=1)
        -> Aggregate using temporary table  (actual time=14.3..14.3 rows=22432 loops=1)
            -> Nested loop inner join  (cost=2573 rows=25012) (actual time=0.439..6.55 rows=23100 loops=1)
                -> Filter: (c1_0.`name` in ('web','education'))  (cost=0.691 rows=2) (actual time=0.0449..0.056 rows=2 loops=1)
                    -> Covering index range scan on c1_0 using UK_category_name over (name = 'education') OR (name = 'web')  (cost=0.691 rows=2) (actual time=0.0419..0.0514 rows=2 loops=1)
                -> Covering index lookup on pc1_0 using idx_category_id_project_id (category_id=c1_0.id)  (cost=661 rows=12506) (actual time=0.264..2.53 rows=11550 loops=2)
```

후
```
-> Filter: (`count(c1_0.``name``)` = 2)  (actual time=5.52..5.53 rows=93 loops=1)
    -> Table scan on <temporary>  (actual time=5.51..5.52 rows=3160 loops=1)
        -> Aggregate using temporary table  (actual time=5.5..5.5 rows=124 loops=1)
            -> Inner hash join (c1_0.id = pc1_0.category_id)  (cost=1064 rows=10) (actual time=5.41..5.42 rows=125 loops=1)
                -> Filter: (c1_0.`name` in ('web','education'))  (cost=0.639 rows=0.2) (actual time=0.0243..0.0267 rows=2 loops=1)
                    -> Covering index range scan on c1_0 using UK_category_name over (name = 'education') OR (name = 'web')  (cost=0.639 rows=2) (actual time=0.0227..0.0248 rows=2 loops=1)
                -> Hash
                    -> Index range scan on pc1_0 using FK_project_category_project over (project_id = 9) OR (project_id = 16) OR (498 more), with index condition: (pc1_0.project_id in (

> techStack이 java 인 project_id

))  (cost=809 rows=500) (actual time=1.39..5.25 rows=728 loops=1)
```
## 🎸 기타

- 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
