### PR TITLE
fix(FE): UnmountAfterAnimation 컴포넌트 기본 html 속성도 넘길 수 있게 수정

### DIFF
--- a/frontend/src/shared/components/FilterContainer/FilterTrigger/FilterTrigger.tsx
+++ b/frontend/src/shared/components/FilterContainer/FilterTrigger/FilterTrigger.tsx
@@ -1,4 +1,4 @@
-import UnmountAfterAnimation from "@shared/components/UnmountAfterAnimation/UnmountAnimation";
+import UnmountAfterAnimation from "@shared/components/UnmountAfterAnimation/UnmountAfterAnimation";
 import { useOutsideClick } from "@shared/hooks/useOutsideClick";
 import useSearchParams from "@shared/hooks/useSearchParams";
 import { type PropsWithChildren, useState } from "react";


### PR DESCRIPTION
## ✅ 체크 리스트

- [X] Target Branch를 올바르게 설정했나요?
- [X] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 🏁 작업 내용

- `UnmountAfterAnimation` 컴포넌트에 기본 html 속성(`aria-label`, `aria-description` 등)도 넘길 수 있게 수정


